### PR TITLE
Remove baselines before drawing.

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -328,6 +328,7 @@ $(document).ready(function() {
             width: trunk.width * 2,
             height: trunk.height,
             right: trunk.right,
+            baselines: [{value:50000000, label:'50M'}],
             xax_count: 4,
             target: 'div#split_by',
             x_accessor: 'date',
@@ -519,6 +520,7 @@ $(document).ready(function() {
                 height: trunk.height,
                 right: trunk.right,
                 xax_count: 4,
+                baselines: [{value:50000000, label:'50M'}],
                 target: 'div#split_by',
                 x_accessor: 'date',
                 y_accessor: new_y_accessor

--- a/js/metrics-graphics.js
+++ b/js/metrics-graphics.js
@@ -540,6 +540,7 @@ function markers(args) {
         }
 
         if(args.baselines) {
+            svg.selectAll('.baselines').remove();
             gb = svg.append('g')
                 .attr('class', 'baselines');
 


### PR DESCRIPTION
If there's a baseline on a graph that can be updated, we should
remove the baselines before drawing, otherwise we end up with
multiple baselines being drawn.
