### PR TITLE
Add code to fix y axis labels for small values.

### DIFF
--- a/js/metrics-graphics.js
+++ b/js/metrics-graphics.js
@@ -329,8 +329,13 @@ function yAxis(args) {
     var yax_format;
     if (args.format == 'count') {
         yax_format = function(f) {
-            var pf = d3.formatPrefix(f);
-            return args.yax_units + pf.scale(f) + pf.symbol;
+            if (f < 1.0) {
+                // Don't scale tiny values.
+                return args.yax_units + d3.round(f, args.decimals);
+            } else {
+                var pf = d3.formatPrefix(f);
+                return args.yax_units + pf.scale(f) + pf.symbol;
+            }
         };
     }
     else {


### PR DESCRIPTION
Before this change, a y-axis value of 0.08 was displayed as "80m",
presumably indicating 80 milli-somethings.

After this change, it shows as 0.08 as expected. The specifics of
how to choose the cutoff are open to debate, but this fixes the
weird display for my use case :)

You can see the data I'm using here:
http://people.mozilla.org/~mreid/telemetry/process_incoming/
