### PR TITLE
Log axis

### DIFF
--- a/js/metrics-graphics.js
+++ b/js/metrics-graphics.js
@@ -454,7 +454,7 @@ function yAxis(args) {
     if (args.y_scale_type == 'log'){
         // get out only whole logs.
         scale_ticks = scale_ticks.filter(function(d){
-            return Math.abs(log10(d)) % 1 === 0 || Math.abs((Math.abs(log10(d)) % 1) - 1) < 1e-6;
+            return Math.abs(log10(d)) % 1 < 1e-6 || Math.abs(log10(d)) % 1 > 1-1e-6;
         });
 
     } 


### PR DESCRIPTION
- fix log axis tick filtering so that it works with negative powers of ten (i.e. 0.1, 0.001, etc.)
- currently, if you make a log plot and the data has a single negative value, the y range minimum was set to 1. So, data that looks like [-2,0.001,0.1] would fail to plot at all.
- set the minimum y range for a log histogram to 0.2 so that bins with a single count show up. I chose 0.2 because anything less than 0.1 would display a y tick at 0.1.
- for a line plot with area I changed the lower line to `args.scales.Y.range()[0]`. Previously it was hard coded to 0 for a linear scale and 1 for a log scale, but it is possible to have log plots with values less than 1.

The best way to see most of the new effects is to edit the beginning of `data/log.json` to look like:

``` javascript
[
    {
        "date": "2014-01-01", 
        "value": -2062.025150690567
    }, 
    {
        "date": "2014-01-02", 
        "value": 0.00615524570567
    }, 
    {
        "date": "2014-01-03", 
        "value": 0.035242208582
    }, 
    {
        "date": "2014-01-04", 
        "value": 0.24929181556
    }, 
    {
        "date": "2014-01-05", 
        "value": 0.70666620035
    }, 
    {
        "date": "2014-01-06", 
        "value": 46173.741222724544
    }, 
    {
        "date": "2014-01-07", 
        "value": 165309.1825970328
    },...
```
