### PR TITLE
Fixes issue #98

### DIFF
--- a/js/metrics-graphics.js
+++ b/js/metrics-graphics.js
@@ -1288,7 +1288,7 @@ charts.line = function(args) {
             }
 
             var g = svg.append('g')
-            .attr('class', 'transparent-rollover-rect')
+                .attr('class', 'transparent-rollover-rect')
 
             var xf = args.data[0].map(args.scalefns.xf);
 


### PR DESCRIPTION
- set the bounding box to be halfway between the previous point and the next point. This should make the rectangles behave saner when there are different spacings in the data.
- It would probably be better to calculate the pixel location from `args.scalefns.xf()` once, as it now is recomputing this value 3x over, but I kept the code closer to the previous style.
