### PR TITLE
Alternate Date/Timestamp Parsing Options

### DIFF
--- a/src/misc/utility.js
+++ b/src/misc/utility.js
@@ -12,9 +12,10 @@ function modify_time_period(data, past_n_days) {
     return data_spliced;
 }
 
-function convert_dates(data, x_accessor) {
+function convert_dates(data, x_accessor, time_format) {
+    time_format = (typeof time_format === "undefined") ? '%Y-%m-%d' : time_format;
     data = data.map(function(d) {
-        var fff = d3.time.format('%Y-%m-%d');
+        var fff = d3.time.format(time_format);
         d[x_accessor] = fff.parse(d[x_accessor]);
         return d;
     });


### PR DESCRIPTION
Thanks again for a great library.

I noticed when using your convenient `convert_dates` method, it only allows parsing of `%Y-%m-%d` style timestamps. My use case included hour and minute, so I extended the method to take in different time parsing, according to https://github.com/mbostock/d3/wiki/Time-Formatting. This third parameter is optional, so this is a non-breaking change for existing implementations.
