### PR TITLE
Add dependency directories to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+bower_components
+node_modules
 
 other/divider.psd
 


### PR DESCRIPTION
Added `bower_components` and `node_modules` to `.gitignore`.

Related to #220
