### PR TITLE
Gulp tasks for checking and building js

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -28,7 +28,10 @@
     "index.htm",
     "dev.htm",
     "examples.htm",
-    "interactive-demo.htm"
+    "interactive-demo.htm",
+    "node_modules",
+    "package.json",
+    "gulpfile.js"
   ],
   "license": "MPL-2.0",
   "authors": [

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,0 +1,69 @@
+// Gulp and plugins
+var
+  gulp = require('gulp'),
+  rimraf = require('gulp-rimraf'),
+  uglify = require('gulp-uglify'),
+  concat = require('gulp-concat'),
+  rename = require('gulp-rename'),
+//sass = require('gulp-sass'), // for building css from scss
+//minifycss = require('gulp-minify-css'), // for minifiing css
+  jslint = require('gulp-jslint');
+
+// paths
+var
+  src = './src/',
+//scss = './scss/',
+//scssFiles = [],
+//scssDependencies = [],
+  dist = './js/',
+  jsFiles = [
+    src + 'common/data_graphic.js',
+    src + 'common/chart_title.js',
+    src + 'common/y_axis.js',
+    src + 'common/x_axis.js',
+    src + 'common/init.js',
+    src + 'common/markers.js',
+    src + 'layout/button.js',
+    src + 'charts/line.js',
+    src + 'charts/histogram.js',
+    src + 'charts/point.js',
+    src + 'charts/bar.js',
+    src + 'charts/table.js',
+    src + 'charts/missing.js',
+    src + 'misc/process.js',
+    src + 'misc/smoothers.js',
+    src + 'misc/utility.js',
+    src + 'misc/error.js'
+  ];
+
+gulp.task('clean', function () {
+  return gulp.src([dist + 'metricsgraphics.js', dist + 'metricsgraphics.min.js'], {read: false})
+    .pipe(rimraf());
+});
+
+// build css files from scss
+//gulp.task('build:css', ['clean'], function () {
+//  return gulp.src(scssFiles)
+//    .pipe(sass({includePaths: scssDependencies}))
+//    .pipe(minifycss())
+//    .pipe(gulp.dest(dist));
+//});
+
+// create 'metricsgraphics.js' and 'metricsgraphics.min.js' from source js
+gulp.task('build:js', ['clean'], function () {
+  return gulp.src(jsFiles)
+    .pipe(concat('metricsgraphics.js'))
+    .pipe(gulp.dest(dist))
+    .pipe(rename('metricsgraphics.min.js'))
+    .pipe(uglify())
+    .pipe(gulp.dest(dist));
+});
+
+// check source js files with jslint
+gulp.task('jslint', function () {
+  return gulp.src(jsFiles)
+    .pipe(jslint({
+      predef: ["window", '$', 'd3'], // used globals
+      nomen: false // true if there are variable names with leading _
+    }));
+});

--- a/package.json
+++ b/package.json
@@ -31,5 +31,13 @@
     "jquery": ">=1.11.1",
     "bootstrap": ">=3.1.1",
     "d3": ">=3.4.8"
+  },
+  "devDependencies": {
+    "gulp": ">=3.8.10",
+    "gulp-rimraf": ">=0.1.1",
+    "gulp-concat": ">=2.4.2",
+    "gulp-rename": ">=1.2.0",
+    "gulp-jslint": ">=0.1.9",
+    "gulp-uglify": ">=1.0.1"
   }
 }


### PR DESCRIPTION
Gulp tasks are added for checking js files with jslint and building target js files with gulp plugins (#222).
File package.json allows to install all requried plugins with console command 'npm install' inside project folder. To run gulp task write in console 'gulp build:js' or 'gulp jslint' inside project folder.

Also I suggest to use scss for styling graphics. With scss you can write for example:

```
$graphics-colors: ['blue', 'red', 'yellow', 'green'];
@for $i from 1 through length($graphics-colors) {
    $color: nth($graphics-colors, $i);
    .area#{$i}-color { fill: $color; }
    .line#{$i}-color { stroke: $color; }
    .line#{$i}-legend-color { color: $color; }
}
```

for styling all your lines, adding style for new line would be fairly simple (just add color to array).
I prepared gulp task for building scss files into css (with minification as bonus).
