### PR TITLE
Fix DOM ordering for redrawn lines/areas

### DIFF
--- a/src/charts/line.js
+++ b/src/charts/line.js
@@ -77,7 +77,8 @@ charts.line = function(args) {
             if(args.area && !args.use_data_y_min && !args.y_axis_negative && args.data.length <= 1) {
                 //if area already exists, transition it
                 if($area.length > 0) {
-                    d3.selectAll($(args.target).find('svg path.area' + (line_id) + '-color'))
+                    $(svg.node()).find('.y-axis').after($area.detach());
+                    d3.select($area.get(0))
                         .transition()
                             .duration(function() {
                                 return (args.transition_on_update) ? 1000 : 0;


### PR DESCRIPTION
Fixes an issue whereby redrawing line charts would cause the axes to appear on top of the line/area. It was only an obvious problem when setting `x_extended_ticks`, `y_extended_ticks` options to true.
