### PR TITLE
Fix #270 (rugs not updating when updating graphs)

### DIFF
--- a/src/common/x_axis.js
+++ b/src/common/x_axis.js
@@ -12,19 +12,25 @@ function x_rug(args) {
         }
     }
 
-    var rug = svg.selectAll('line.x_rug').data(all_data)
-        .enter().append('svg:line')
-            .attr('x1', args.scalefns.xf)
-            .attr('x2', args.scalefns.xf)
-            .attr('y1', args.height-args.top+buffer_size)
-            .attr('y2', args.height-args.top)
-            .attr('class', 'x-rug')
-            .attr('opacity', 0.3);
+    var rug = svg.selectAll('line.x-rug').data(all_data);
+
+    rug.enter().append('svg:line')
+        .attr('class', 'x-rug')
+        .attr('opacity', 0.3);
+
+    rug.exit().remove();
+
+    rug.attr('x1', args.scalefns.xf)
+        .attr('x2', args.scalefns.xf)
+        .attr('y1', args.height-args.top+buffer_size)
+        .attr('y2', args.height-args.top);
 
     if (args.color_accessor) {
         rug.attr('stroke', args.scalefns.color);
+        rug.classed('x-rug-mono', false);
     }
     else {
+        rug.attr('stroke', null);
         rug.classed('x-rug-mono', true);
     }
 }

--- a/src/common/y_axis.js
+++ b/src/common/y_axis.js
@@ -11,19 +11,25 @@ function y_rug(args) {
             all_data.push(args.data[i][j]);
         }
     }
-    var rug = svg.selectAll('line.y_rug').data(all_data)
-        .enter().append('svg:line')
-            .attr('x1', args.left + 1)
-            .attr('x2', args.left+buffer_size)
-            .attr('y1', args.scalefns.yf)
-            .attr('y2', args.scalefns.yf)
-            .attr('class', 'y-rug')
-            .attr('opacity', 0.3);
+    var rug = svg.selectAll('line.y-rug').data(all_data);
+
+    rug.enter().append('svg:line')
+        .attr('class', 'y-rug')
+        .attr('opacity', 0.3);
+
+    rug.exit().remove();
+
+    rug.attr('x1', args.left + 1)
+        .attr('x2', args.left+buffer_size)
+        .attr('y1', args.scalefns.yf)
+        .attr('y2', args.scalefns.yf);
 
     if (args.color_accessor) {
         rug.attr('stroke', args.scalefns.color);
+        rug.classed('y-rug-mono', false);
     }
     else {
+        rug.attr('stroke', null);
         rug.classed('y-rug-mono', true);
     }
 }


### PR DESCRIPTION
Hello! This pull request fixes #270, "rugs not updating when updating a graph".
- The selector for the rug's tick elements, `line.x_rug`, is fixed to read `line.x-rug`. This allows d3 to select existing `line`-elements for updating instead of creating a full new set.
- Any `line`-element that is not in use is removed by the call to `rug.exit().remove()`.

Following d3's [general update pattern](http://bl.ocks.org/mbostock/3808218), the `attr()` calls after `rug.enter().append()` only set the attributes that do not change after initialization (`class=x-rug` and `opacity`). The later `rug.attr()` calls then update all elements, new and old, with the attributes that may require change between updates (`x1`, `x2`, `y1`, `y2`, and `stroke`).

The changes to `y_axis.js` are very similar to those in `x_axis.js`.
