### PR TITLE
Fix possibly-undefined use of local `pp` variable.

### DIFF
--- a/src/js/charts/bar.js
+++ b/src/js/charts/bar.js
@@ -83,7 +83,7 @@ charts.bar = function(args) {
             }
 
             if (args.baseline_accessor) {
-                predictor_bars = barplot.selectAll('.mg-bar-baseline');
+                baseline_marks = barplot.selectAll('.mg-bar-baseline');
             }
         }
 

--- a/src/js/charts/bar.js
+++ b/src/js/charts/bar.js
@@ -143,6 +143,7 @@ charts.bar = function(args) {
             }
 
             if (args.baseline_accessor){
+                var pp = args.predictor_proportion;
 
                 if (perform_load_animation) {
                     baseline_marks.attr({y1: args.scales.Y(0), y2: args.scales.Y(0)})
@@ -214,6 +215,7 @@ charts.bar = function(args) {
             }
 
             if (args.baseline_accessor){
+                var pp = args.predictor_proportion;
 
                 if (perform_load_animation) {
                     baseline_marks


### PR DESCRIPTION
When rendering a bar chart, the `if (args.baseline_accessor)` branch uses a local variable `pp` to cache `args.predictor_proportion`.  However this variable is only defined in the `if (args.predictor_accessor)` branch, so it errors out if you ask for a chart with `baseline_accessor` but not `predictor_accessor`.

This PR duplicates the definition of `var pp` into the `if (args.baseline_accessor)` branch, which fixes the problem for me.  It may be preferable to lift it out into the containing scope, not sure what the style preferences are here.