### PR TITLE
Fixing tests for PhantomJS

### DIFF
--- a/testem.json
+++ b/testem.json
@@ -31,5 +31,6 @@
   ],
   "launch_in_dev": [
     "PhantomJS"
-  ]
+  ],
+  "phantomjs_debug_port": 9000
 }

--- a/tests/charts/line_test.js
+++ b/tests/charts/line_test.js
@@ -22,7 +22,7 @@ test('Only one confidence is added on multiple calls to the same target element'
 
     MG.data_graphic(params);
     MG.data_graphic(MG.clone(params));
-    
+
     equal(document.querySelectorAll(target + ' .mg-confidence-band').length, 1, 'We only have one confidence band');
 });
 
@@ -154,6 +154,6 @@ test('There are as many lines as data series (two) on multiple calls to an exist
 
     MG.data_graphic(params);
     MG.data_graphic(MG.clone(params));
-    
+
     equal(document.querySelectorAll('.mg-main-line').length, 2, 'Two lines exist');
 });

--- a/tests/charts/missing_test.js
+++ b/tests/charts/missing_test.js
@@ -8,7 +8,7 @@ test('Missing chart\'s text matches specified missing_text', function() {
     };
 
     MG.data_graphic(params);
-    equal(document.querySelector('.mg-missing-text').innerHTML, 
-        params.missing_text, 
+    equal(document.querySelector('.mg-missing-text').textContent,
+        params.missing_text,
         'Missing chart\'s text matches missing_text');
 });

--- a/tests/common/init_test.js
+++ b/tests/common/init_test.js
@@ -6,7 +6,7 @@ test('Chart\'s width is set correctly on subsequent calls to existing chart', fu
         data: [{'date': new Date('2014-11-01'), 'value': 12},
                {'date': new Date('2014-11-02'), 'value': 18}],
     };
-    
+
     var params = {
         target: '#qunit-fixture',
         data: [{'date': new Date('2014-11-01'), 'value': 12},
@@ -17,7 +17,7 @@ test('Chart\'s width is set correctly on subsequent calls to existing chart', fu
 
     MG.data_graphic(params_0);
     MG.data_graphic(params);
-    
+
     var width = document.querySelector(params.target + ' svg').offsetWidth;
     ok(width == params.width, 'SVG\'s width matches latest specified width');
 });
@@ -28,7 +28,7 @@ test('Chart\'s height is set correctly on subsequent calls to existing chart', f
         data: [{'date': new Date('2014-11-01'), 'value': 12},
                {'date': new Date('2014-11-02'), 'value': 18}],
     };
-    
+
     var params = {
         target: '#qunit-fixture',
         data: [{'date': new Date('2014-11-01'), 'value': 12},
@@ -39,7 +39,7 @@ test('Chart\'s height is set correctly on subsequent calls to existing chart', f
 
     MG.data_graphic(params_0);
     MG.data_graphic(params);
-    
+
     var height = document.querySelector(params.target + ' svg').offsetHeight;
     ok(height == params.height, 'SVG\'s height matches latest specified height');
 });
@@ -50,7 +50,7 @@ test('Charts are plotted correctly when MG is called multiple times on the same 
         data: [{'date': new Date('2014-11-01'), 'value': 12},
                {'date': new Date('2014-11-02'), 'value': 18}],
     };
-    
+
     var params = {
         target: '#qunit-fixture',
         data: [{'date': new Date('2014-11-01'), 'value': 12},
@@ -61,14 +61,14 @@ test('Charts are plotted correctly when MG is called multiple times on the same 
 
     MG.data_graphic(params_0);
     MG.data_graphic(params);
-    
+
     //ensure chart types change appropriately
     var line = document.querySelector('.mg-main-line');
     ok(line, 'chart_type is `line`, line chart is plotted');
 
-    //check all the other chart types    
-    var chart_types = [{id: 'point', domElement: '.mg-points'}, 
-        {id: 'histogram', domElement: '.mg-histogram'}, 
+    //check all the other chart types
+    var chart_types = [{id: 'point', domElement: '.mg-points'},
+        {id: 'histogram', domElement: '.mg-histogram'},
         {id: 'bar', domElement: '.mg-barplot'}];
 
     for(var i = 0; i < chart_types.length; i++) {
@@ -80,14 +80,15 @@ test('Charts are plotted correctly when MG is called multiple times on the same 
             width: 200,
             height: 100,
         };
-        
+
         MG.data_graphic(params);
-        ok(document.querySelector(chart_types[i].domElement), 
+        ok(document.querySelector(chart_types[i].domElement),
             'chart_type switched to `' + chart_types[i].id + '`, the correct chart type is plotted');
     }
 });
 
 test('Missing chart has required class name set', function() {
+    expect(1);
     var params = {
         target: '#qunit-fixture',
         data: [{'date': new Date('2014-11-01'), 'value': 12},
@@ -97,8 +98,8 @@ test('Missing chart has required class name set', function() {
 
     MG.data_graphic(params);
 
-    var classname = document.querySelector(params.target + ' svg').classList.contains('mg-missing');
-    ok(target, 'Missing chart has class `missing` set');
+    var matches = document.querySelector(params.target + ' svg').getAttribute('class').match(/mg-missing/);
+    ok(matches, 'Missing chart has class `missing` set');
 });
 
 test('Linked chart has the required class set', function() {
@@ -111,8 +112,8 @@ test('Linked chart has the required class set', function() {
 
     MG.data_graphic(params);
 
-    var classname = document.querySelector(params.target + ' svg').classList.contains('linked');
-    ok(target, 'Linked chart has class `linked` set');
+    var matches = document.querySelector(params.target + ' svg').getAttribute('class').match(/linked/);
+    ok(matches, 'Linked chart has class `linked` set');
 });
 
 test('args.time_series is set to true when data is time-series', function() {

--- a/tests/common/markers_test.js
+++ b/tests/common/markers_test.js
@@ -71,8 +71,8 @@ test('Markers\' texts are correctly added', function() {
     };
 
     MG.data_graphic(params);
-    equal(document.querySelectorAll(target + ' .mg-markers text')[0].innerHTML, markers[0].label, 'First marker\'s text matches specified one');
-    equal(document.querySelectorAll(target + ' .mg-markers text')[1].innerHTML, markers[1].label, 'Second marker\'s text matches specified one');
+    equal(document.querySelectorAll(target + ' .mg-markers text')[0].textContent, markers[0].label, 'First marker\'s text matches specified one');
+    equal(document.querySelectorAll(target + ' .mg-markers text')[1].textContent, markers[1].label, 'Second marker\'s text matches specified one');
 });
 
 test('Baseline text is correctly added', function() {
@@ -86,5 +86,5 @@ test('Baseline text is correctly added', function() {
     };
 
     MG.data_graphic(params);
-    equal(document.querySelectorAll(target + ' .mg-baselines text')[0].innerHTML, baselines[0].label, 'Baseline text matches specified one');
+    equal(document.querySelectorAll(target + ' .mg-baselines text')[0].textContent, baselines[0].label, 'Baseline text matches specified one');
 });

--- a/tests/common/y_axis_test.js
+++ b/tests/common/y_axis_test.js
@@ -32,7 +32,7 @@ test('Only one y-axis is added on multiple calls to the same target element', fu
 
     MG.data_graphic(params);
     MG.data_graphic(MG.clone(params));
-    
+
     equal(document.querySelectorAll(target + ' .mg-y-axis').length, 1, 'We only have one y-axis');
 });
 
@@ -102,7 +102,7 @@ test('Default min_y is 0', function() {
     };
 
     MG.data_graphic(params);
-    equal(document.querySelector('.mg-y-axis text').innerHTML, 0, 'Y-axis starts at 0');
+    equal(document.querySelector('.mg-y-axis text').textContent, 0, 'Y-axis starts at 0');
 });
 
 test('args.min_y_from_data', function() {
@@ -114,7 +114,7 @@ test('args.min_y_from_data', function() {
     };
 
     MG.data_graphic(params);
-    equal(document.querySelector('.mg-y-axis text').innerHTML, 12, 'Y-axis starts at 12');
+    equal(document.querySelector('.mg-y-axis text').textContent, 12, 'Y-axis starts at 12');
 });
 
 test('args.min_y set to arbitrary value', function() {
@@ -126,7 +126,7 @@ test('args.min_y set to arbitrary value', function() {
     };
 
     MG.data_graphic(params);
-    equal(document.querySelector('.mg-y-axis text').innerHTML, 5, 'Y-axis starts at 5');
+    equal(document.querySelector('.mg-y-axis text').textContent, 5, 'Y-axis starts at 5');
 });
 
 test('args.y_extended_ticks', function() {
@@ -150,7 +150,7 @@ test('args.format is set to percentage', function() {
     };
 
     MG.data_graphic(params);
-    equal(document.querySelector('.mg-y-axis text').innerHTML.slice(-1), '%', 'Y-axis units are %');
+    equal(document.querySelector('.mg-y-axis text').textContent.slice(-1), '%', 'Y-axis units are %');
 });
 
 test('args.yax_units', function() {
@@ -162,7 +162,7 @@ test('args.yax_units', function() {
     };
 
     MG.data_graphic(params);
-    equal(document.querySelector('.mg-y-axis text').innerHTML[0], '$', 'Y-axis units are $');
+    equal(document.querySelector('.mg-y-axis text').textContent[0], '$', 'Y-axis units are $');
 });
 
 test('When args.max_y is set, ignore inflator', function() {
@@ -175,5 +175,5 @@ test('When args.max_y is set, ignore inflator', function() {
 
     MG.data_graphic(params);
     var nodes = document.querySelectorAll('.mg-y-axis text');
-    equal(nodes[nodes.length - 1].innerHTML, 50, 'Maximum y-axis value is 50');
+    equal(nodes[nodes.length - 1].textContent, 50, 'Maximum y-axis value is 50');
 });


### PR DESCRIPTION
Enabling PhantomJS debugger on port 9000 (in `testem.json`)

Fixes a few false-positives in `init_test.js`

Resolves errors caused by PhantomJS' strict adherence to SVG vs HTML accessors - looks like browsers are more lenient when mixing SVG and HTML elements: 
- `innerHTML` becomes `textContent`
- `classList.contains("...")` becomes `getAttribute('class').match(/.../)`