### PR TITLE
Added .editorconfig for consistency across IDEs

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,32 @@
+# EditorConfig helps developers define and maintain consistent
+# coding styles between different editors and IDEs
+# editorconfig.org
+
+root = true
+
+[*]
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+indent_style = space
+indent_size = 4
+
+[*.js]
+indent_style = space
+indent_size = 4
+
+[*.hbs]
+indent_style = space
+indent_size = 4
+
+[*.css]
+indent_style = space
+indent_size = 4
+
+[*.html]
+indent_style = space
+indent_size = 4
+
+[*.{diff,md}]
+trim_trailing_whitespace = false


### PR DESCRIPTION
I'm always switching between 4 and 2 spaced indents (if I even remember) depending which project I'm working on. The addition of an `.editorconfig` file means this can now happen automatically.

See http://editorconfig.org/#download for supported editors and IDEs.