### PR TITLE
Linked minutes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: node_js
 node_js:
   - "0.10"
+script: npm run test-ci
 notifications:
   irc:
     channels:

--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
   "description": "A library optimized for concise, principled data graphics and layouts",
   "main": "dist/metricsgraphics.js",
   "scripts": {
-    "test": "./node_modules/testem/testem.js ci testem.json"
+    "build": "gulp build:js",
+    "test": "gulp test",
+    "test-ci": "./node_modules/testem/testem.js ci testem.json"
   },
   "repository": {
     "type": "git",

--- a/src/js/charts/line.js
+++ b/src/js/charts/line.js
@@ -246,7 +246,7 @@ charts.line = function(args) {
                         .attr('class', function(d) {
                             if (args.linked) {
                                 var v = d[args.x_accessor];
-                                var formatter = d3.time.format('%Y-%m-%d');
+                                var formatter = d3.time.format(args.linked_format || '%Y-%m-%d');
 
                                 //only format when x-axis is date
                                 var id = (typeof v === 'number')
@@ -328,7 +328,7 @@ charts.line = function(args) {
                         .attr('class', function(d, i) {
                             if (args.linked) {
                                 var v = d[args.x_accessor];
-                                var formatter = d3.time.format('%Y-%m-%d');
+                                var formatter = d3.time.format(args.linked_format || '%Y-%m-%d');
 
                                 //only format when x-axis is date
                                 var id = (typeof v === 'number')
@@ -453,7 +453,7 @@ charts.line = function(args) {
                     MG.globals.link = true;
 
                     var v = d[args.x_accessor];
-                    var formatter = d3.time.format('%Y-%m-%d');
+                    var formatter = d3.time.format(args.linked_format || '%Y-%m-%d');
 
                     //only format when y-axis is date
                     var id = (typeof v === 'number')
@@ -593,7 +593,7 @@ charts.line = function(args) {
                 MG.globals.link = false;
 
                 var v = d[args.x_accessor];
-                var formatter = d3.time.format('%Y-%m-%d');
+                var formatter = d3.time.format(args.linked_format || '%Y-%m-%d');
 
                 //only format when y-axis is date
                 var id = (typeof v === 'number')

--- a/src/js/charts/line.js
+++ b/src/js/charts/line.js
@@ -246,7 +246,7 @@ charts.line = function(args) {
                         .attr('class', function(d) {
                             if (args.linked) {
                                 var v = d[args.x_accessor];
-                                var formatter = d3.time.format(args.linked_format || '%Y-%m-%d');
+                                var formatter = d3.time.format(args.linked_format);
 
                                 //only format when x-axis is date
                                 var id = (typeof v === 'number')
@@ -328,7 +328,7 @@ charts.line = function(args) {
                         .attr('class', function(d, i) {
                             if (args.linked) {
                                 var v = d[args.x_accessor];
-                                var formatter = d3.time.format(args.linked_format || '%Y-%m-%d');
+                                var formatter = d3.time.format(args.linked_format);
 
                                 //only format when x-axis is date
                                 var id = (typeof v === 'number')
@@ -453,7 +453,7 @@ charts.line = function(args) {
                     MG.globals.link = true;
 
                     var v = d[args.x_accessor];
-                    var formatter = d3.time.format(args.linked_format || '%Y-%m-%d');
+                    var formatter = d3.time.format(args.linked_format);
 
                     //only format when y-axis is date
                     var id = (typeof v === 'number')
@@ -593,7 +593,7 @@ charts.line = function(args) {
                 MG.globals.link = false;
 
                 var v = d[args.x_accessor];
-                var formatter = d3.time.format(args.linked_format || '%Y-%m-%d');
+                var formatter = d3.time.format(args.linked_format);
 
                 //only format when y-axis is date
                 var id = (typeof v === 'number')

--- a/src/js/common/data_graphic.js
+++ b/src/js/common/data_graphic.js
@@ -65,6 +65,7 @@ MG.data_graphic = function() {
         format: 'count',              // format = {count, percentage}
         inflator: 10/9,               // for setting y axis max
         linked: false,                // links together all other graphs with linked:true, so rollovers in one trigger rollovers in the others
+        linked_format: '%Y-%m-%d',    // What granularity to link on for graphs. Default is at day
         list: false,
         baselines: null,              // sets the baseline lines
         markers: null,                // sets the marker lines


### PR DESCRIPTION
It seems as it isn't possible to have linked graphs on anything other than days, due to the hardcoded parsing for dates. This PR adds possibility to override this format, and thus being able to do linked hover on self defined granularity.

This PR also adds convenience npm scripts for building and testing:

```shell
$ npm run build
```

```shell
$ npm test
```

This makes it so that gulp doesn't have to be installed globally and thus makes it easier to have different gulp version across different projects.