### PR TITLE
Changes order of drawing markers. Making the order same for each graph

### DIFF
--- a/src/js/common/data_graphic.js
+++ b/src/js/common/data_graphic.js
@@ -194,7 +194,7 @@ MG.data_graphic = function() {
     }
     else {
         args = merge_with_defaults(args, defaults.all);
-        charts.line(args).markers().mainPlot().rollover().windowListeners();
+        charts.line(args).mainPlot().markers().rollover().windowListeners();
     }
 
     return args.data;


### PR DESCRIPTION
For some reason the draw order of the line chart is different than the other graphs, but only on initial draw. This cause the markers in the line chart to first be behind confidence area and on update in front, which looks weird.

This PR changes the draw order of line chart to be the same as the order of the other charts.