### PR TITLE
Working a little on that GPA

### DIFF
--- a/.jshintignore
+++ b/.jshintignore
@@ -1,0 +1,2 @@
+src/js/common/bootstrap_tooltip_popover.js
+src/js/layout/bootstrap_dropdown.js

--- a/.jshintrc
+++ b/.jshintrc
@@ -6,5 +6,7 @@
     "d3": false
   },
   "laxbreak": true,
-  "validthis": true
+  "validthis": true,
+  "loopfunc": true,
+  "sub": true
 }

--- a/.jshintrc
+++ b/.jshintrc
@@ -5,5 +5,6 @@
     "MG": false,
     "d3": false
   },
-  "laxbreak": true
+  "laxbreak": true,
+  "validthis": true
 }

--- a/gulp/index.js
+++ b/gulp/index.js
@@ -8,7 +8,7 @@ var
   rename = require('gulp-rename'),
 //sass = require('gulp-sass'), // for building css from scss
 //minifycss = require('gulp-minify-css'), // for minifiing css
-  jslint = require('gulp-jslint'),
+  jshint = require('gulp-jshint'),
   testem = require('gulp-testem'),
   connect = require('gulp-connect'),
   es6ModuleTranspiler = require("gulp-es6-module-transpiler");
@@ -45,7 +45,7 @@ var
   ];
 
 
-gulp.task('default', ['jslint', 'test', 'build:js']);
+gulp.task('default', ['jshint', 'test', 'build:js']);
 
 gulp.task('clean', function () {
   return gulp.src([dist + 'metricsgraphics.js', dist + 'metricsgraphics.min.js'], {read: false})
@@ -100,13 +100,11 @@ gulp.task('build:js', ['clean'], function () {
     .pipe(gulp.dest(dist));
 });
 
-// Check source js files with jslint
-gulp.task('jslint', function () {
+// Check source js files with jshint
+gulp.task('jshint', function () {
   return gulp.src(jsFiles)
-    .pipe(jslint({
-      predef: ["window", '$', 'd3'], // used globals
-      nomen: false // true if there are variable names with leading _
-    }));
+    .pipe(jshint())
+    .pipe(jshint.reporter('default'));
 });
 
 // Run test suite server (testem')

--- a/gulp/index.js
+++ b/gulp/index.js
@@ -123,9 +123,9 @@ var roots = ['dist', 'examples', 'src'],
         return root + '/**/*';
     });
 
-gulp.task('dev:watch', function() { return gulp.watch(watchables, ['dev:reload']); });
+gulp.task('dev:watch', function() { return gulp.watch(watchables, ['jshint', 'dev:reload']); });
 gulp.task('dev:reload', function() { return gulp.src(watchables).pipe(connect.reload()); });
-gulp.task('serve', ['dev:serve', 'dev:watch']);
+gulp.task('serve', ['jshint', 'dev:serve', 'dev:watch']);
 
 gulp.task('dev:serve', function() {
     connect.server({

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "gulp-concat": "^2.4.2",
     "gulp-connect": "^2.2.0",
     "gulp-es6-module-transpiler": "^0.2.0",
-    "gulp-jslint": "^0.2.1",
+    "gulp-jshint": "^1.9.0",
     "gulp-rename": "^1.2.0",
     "gulp-rimraf": "^0.1.1",
     "gulp-testem": "0.0.1",

--- a/src/js/MG.js
+++ b/src/js/MG.js
@@ -1,1 +1,1 @@
-var MG = {version:'2.1.0'};
+var MG = {version: '2.1.0'};

--- a/src/js/MG.js
+++ b/src/js/MG.js
@@ -1,1 +1,1 @@
-var MG = {version: '2.1.0'};
+window.MG = {version: '2.1.0'};

--- a/src/js/charts/bar.js
+++ b/src/js/charts/bar.js
@@ -35,6 +35,7 @@ charts.bar = function(args) {
 
         var bars;
         var predictor_bars;
+        var pp, pp0;
         var baseline_marks;
 
         var perform_load_animation = fresh_render && args.animate_on_load;
@@ -114,8 +115,8 @@ charts.bar = function(args) {
                 });
 
             if (args.predictor_accessor) {
-                var pp = args.predictor_proportion;
-                var pp0 = pp-1;
+                pp = args.predictor_proportion;
+                pp0 = pp-1;
 
                 if (perform_load_animation) {
                     predictor_bars.attr('height', 0)
@@ -142,7 +143,7 @@ charts.bar = function(args) {
             }
 
             if (args.baseline_accessor) {
-                var pp = args.predictor_proportion;
+                pp = args.predictor_proportion;
 
                 if (perform_load_animation) {
                     baseline_marks.attr({y1: args.scales.Y(0), y2: args.scales.Y(0)});
@@ -186,8 +187,8 @@ charts.bar = function(args) {
 
 
             if (args.predictor_accessor) {
-                var pp = args.predictor_proportion;
-                var pp0 = pp-1;
+                pp = args.predictor_proportion;
+                pp0 = pp-1;
 
                 if (perform_load_animation) {
                     predictor_bars.attr('width', 0);
@@ -211,7 +212,7 @@ charts.bar = function(args) {
             }
 
             if (args.baseline_accessor) {
-                var pp = args.predictor_proportion;
+                pp = args.predictor_proportion;
 
                 if (perform_load_animation) {
                     baseline_marks
@@ -261,7 +262,7 @@ charts.bar = function(args) {
             .attr('dy', '.35em')
             .attr('text-anchor', 'end');
 
-        var g = svg.append('g')
+        g = svg.append('g')
             .attr('class', 'mg-rollover-rect');
 
         //draw rollover bars

--- a/src/js/charts/table.js
+++ b/src/js/charts/table.js
@@ -4,7 +4,7 @@ Data Tables
 Along with histograms, bars, lines, and scatters, a simple data table can take you far.
 We often just want to look at numbers, organized as a table, where columns are variables,
 and rows are data points. Sometimes we want a cell to have a small graphic as the main
-column element, in which case we want small multiples. sometimes we want to 
+column element, in which case we want small multiples. sometimes we want to
 
 var table = New data_table(data)
                 .target('div#data-table')
@@ -31,9 +31,9 @@ MG.data_table = function(args) {
         this.formatting_options.forEach(function(fo) {
             var attr = fo[0];
             var key = fo[1];
-            if (args[key]) element.style(attr, 
-                typeof args[key] === 'string' || 
-                typeof args[key] === 'number' ? 
+            if (args[key]) element.style(attr,
+                typeof args[key] === 'string' ||
+                typeof args[key] === 'number' ?
                     args[key] : args[key](value));
         });
     };
@@ -63,7 +63,7 @@ MG.data_table = function(args) {
 
     this.bullet = function() {
         /*
-        text label 
+        text label
         main value
         comparative measure
         any number of ranges
@@ -101,10 +101,11 @@ MG.data_table = function(args) {
 
         var tr, th, td_accessor, td_type, td_value, th_text, td_text, td;
         var col;
+        var h;
 
         tr = thead.append('tr');
 
-        for (var h = 0; h < args.columns.length; h++) {
+        for (h = 0; h < args.columns.length; h++) {
             var this_col = args.columns[h];
             td_type = this_col.type;
             th_text = this_col.label;
@@ -131,7 +132,7 @@ MG.data_table = function(args) {
             }
         }
 
-        for (var h = 0; h < args.columns.length; h++) {
+        for (h = 0; h < args.columns.length; h++) {
             col = colgroup.append('col');
             if (args.columns[h].type === 'number') {
                 col.attr('align', 'char').attr('char', '.');

--- a/src/js/common/init.js
+++ b/src/js/common/init.js
@@ -6,7 +6,6 @@ function init(args) {
         description: null
     };
 
-    var args = arguments[0];
     if (!args) { args = {}; }
     args = merge_with_defaults(args, defaults);
 
@@ -97,7 +96,7 @@ function init(args) {
 
     // remove missing class
     svg.classed('mg-missing', false);
-    
+
     // remove missing text
     svg.selectAll('.mg-missing-text').remove();
     svg.selectAll('.mg-missing-pane').remove();
@@ -113,13 +112,15 @@ function init(args) {
     //if we're updating an existing chart and we have fewer lines than
     //before, remove the outdated lines, e.g. if we had 3 lines, and we're calling
     //data_graphic() on the same target with 2 lines, remove the 3rd line
+
+    var i;
     if(args.data.length < $(args.target).find('svg .mg-main-line').length) {
         //now, the thing is we can't just remove, say, line3 if we have a custom
         //line-color map, instead, see which are the lines to be removed, and delete those
         if(args.custom_line_color_map.length > 0) {
             var array_full_series = function(len) {
                 var arr = new Array(len);
-                for(var i=0;i<arr.length;i++) { arr[i] = i + 1; }
+                for(i = 0; i < arr.length; i++) { arr[i] = i + 1; }
                 return arr;
             };
 
@@ -128,7 +129,7 @@ function init(args) {
                 array_full_series(args.max_data_size),
                 args.custom_line_color_map);
 
-            for(var i=0; i<lines_to_remove.length; i++) {
+            for(i = 0; i<lines_to_remove.length; i++) {
                 $(args.target).find('svg .mg-main-line.mg-line' + lines_to_remove[i] + '-color')
                     .remove();
             }
@@ -138,7 +139,7 @@ function init(args) {
             var num_of_new = args.data.length;
             var num_of_existing = $(args.target).find('svg .mg-main-line').length;
 
-            for(var i=num_of_existing; i>num_of_new; i--) {
+            for(i = num_of_existing; i>num_of_new; i--) {
                 $(args.target).find('svg .mg-main-line.mg-line' + i + '-color').remove();
             }
         }

--- a/src/js/common/x_axis.js
+++ b/src/js/common/x_axis.js
@@ -149,7 +149,7 @@ function x_axis_categorical(args) {
 }
 
 function mg_point_add_color_scale(args) {
-    var min_color, max_color, 
+    var min_color, max_color,
         color_domain, color_range;
 
     if (args.color_accessor !== null) {
@@ -294,8 +294,8 @@ function mg_default_xax_format(args) {
         return args.xax_format;
     }
 
-    var diff, 
-        main_time_format, 
+    var diff,
+        main_time_format,
         time_frame;
 
     if (args.time_series) {
@@ -332,7 +332,7 @@ function mg_default_xax_format(args) {
                 //don't scale tiny values
                 return args.yax_units + d3.round(d, args.decimals);
             } else {
-                var pf = d3.formatPrefix(d);
+                pf = d3.formatPrefix(d);
                 return args.xax_units + pf.scale(d) + pf.symbol;
             }
         } else {
@@ -392,7 +392,7 @@ function mg_add_x_tick_labels(g, args) {
                 });
 
     if (args.time_series && (args.show_years || args.show_secondary_x_label)) {
-        var secondary_marks, 
+        var secondary_marks,
             secondary_function, yformat;
 
         var time_frame = args.processed.x_time_frame;
@@ -416,7 +416,7 @@ function mg_add_x_tick_labels(g, args) {
         }
 
         var years = secondary_function(args.processed.min_x, args.processed.max_x);
-       
+
         if (years.length === 0) {
             var first_tick = args.scales.X.ticks(args.xax_count)[0];
             years = [first_tick];
@@ -434,7 +434,7 @@ function mg_add_x_tick_labels(g, args) {
                         .attr('x1', function(d) { return args.scales.X(d).toFixed(2); })
                         .attr('x2', function(d) { return args.scales.X(d).toFixed(2); })
                         .attr('y1', args.top)
-                        .attr('y2', args.height - args.bottom);    
+                        .attr('y2', args.height - args.bottom);
         }
 
         g.selectAll('.mg-year-marker')
@@ -451,8 +451,8 @@ function mg_add_x_tick_labels(g, args) {
 }
 
 function mg_find_min_max_x(args) {
-    var last_i, 
-        min_x, 
+    var last_i,
+        min_x,
         max_x;
 
     if (args.chart_type === 'line') {
@@ -475,7 +475,7 @@ function mg_find_min_max_x(args) {
         max_x = d3.max(args.data[0], function(d) { return d[args.x_accessor]; });
 
     } else if (args.chart_type === 'bar') {
-        min_x = 0; 
+        min_x = 0;
         max_x = d3.max(args.data[0], function(d) {
             var trio = [];
             trio.push(d[args.x_accessor]);
@@ -494,7 +494,7 @@ function mg_find_min_max_x(args) {
 
     //if data set is of length 1, expand the range so that we can build the x-axis
     //of course, a line chart doesn't make sense in this case, so the preferred
-    //method would be to check for said object's length and, if appropriate, 
+    //method would be to check for said object's length and, if appropriate,
     //change the chart type to 'point'
     if (min_x === max_x) {
         if (min_x instanceof Date) {
@@ -510,7 +510,7 @@ function mg_find_min_max_x(args) {
             min_x = Number(min_x) - 1;
             max_x = Number(max_x) + 1;
         }
-        
+
         //force xax_count to be 2
         args.xax_count = 2;
     }

--- a/src/js/common/y_axis.js
+++ b/src/js/common/y_axis.js
@@ -49,26 +49,26 @@ function y_axis(args) {
     var $svg = $($(args.target).find('svg').get(0));
     var g;
 
-    var min_y, 
+    var min_y,
         max_y;
 
     args.scalefns.yf = function(di) {
         return args.scales.Y(di[args.y_accessor]);
     };
 
-    var _set = false;
+    var _set = false,
+        gtZeroFilter = function(d) { return d[args.y_accessor] > 0; },
+        mapToY = function(d) { return d[args.y_accessor]; };
     for (var i = 0; i < args.data.length; i++) {
         var a = args.data[i];
 
         if (args.y_scale_type === 'log') {
             // filter positive values
-            a = a.filter(function(d) { return d[args.y_accessor] > 0; });
+            a = a.filter(gtZeroFilter);
         }
 
         if (a.length > 0) { // get min/max in one pass
-            var extent = d3.extent(a,function(d) {
-                return d[args.y_accessor];
-            });
+            var extent = d3.extent(a, mapToY);
 
             if (!_set) {
                 // min_y and max_y haven't been set

--- a/src/js/layout/button.js
+++ b/src/js/layout/button.js
@@ -51,13 +51,17 @@ MG.button_layout = function(target) {
 
         var d,f, features, feat;
         features = Object.keys(this.feature_set);
-        
+
+        var mapDtoF = function(f) { return d[f]; };
+
+        var i;
+
         // build out this.feature_set with this.data
-        for (var i=0; i < this._data.length; i++) {
+        for (i = 0; i < this._data.length; i++) {
             d = this._data[i];
-            f = features.map(function(f) { return d[f]; });
+            f = features.map(mapDtoF);
             for (var j = 0; j < features.length; j++) {
-                feat = features[j]; 
+                feat = features[j];
                 if (this.feature_set[feat].indexOf(f[j]) === -1) {
                     this.feature_set[feat].push(f[j]);
                 }
@@ -74,6 +78,21 @@ MG.button_layout = function(target) {
 
         $(this.target).append("<div class='col-lg-12 segments text-center'></div>");
 
+        var dropdownLiAClick = function() {
+            var k = $(this).data('key');
+            var feature = $(this).data('feature');
+            var manual_feature;
+            $('.' + feature + '-btns button.btn span.title').html(k);
+            if (!manual_map.hasOwnProperty(feature)) {
+                callback(feature, k);
+            } else {
+                manual_feature = manual_map[feature];
+                manual_callback[manual_feature](k);
+            }
+
+            return false;
+        };
+
         for (var feature in this.feature_set) {
             features = this.feature_set[feature];
             $(this.target + ' div.segments').append(
@@ -81,7 +100,7 @@ MG.button_layout = function(target) {
                     '<button type="button" class="btn btn-default btn-lg dropdown-toggle" data-toggle="dropdown">' +
                         "<span class='which-button'>" + (this.public_name.hasOwnProperty(feature) ? this.public_name[feature] : feature) +"</span>" +
                         "<span class='title'>" + (this.manual_callback.hasOwnProperty(feature) ? this.feature_set[feature][0] : 'all') +  "</span>" + // if a manual button, don't default to all in label.
-                        '<span class="caret"></span>' + 
+                        '<span class="caret"></span>' +
                     '</button>' +
                     '<ul class="dropdown-menu" role="menu">' +
                         (!this.manual_callback.hasOwnProperty(feature) ? '<li><a href="#" data-feature="'+feature+'" data-key="all">All</a></li>' : "") +
@@ -89,33 +108,20 @@ MG.button_layout = function(target) {
                     '</ul>'
             + '</div>');
 
-            for (var i = 0; i < features.length; i++) {
+            for (i = 0; i < features.length; i++) {
                 if (features[i] !== 'all' && features[i] !== undefined) { // strange bug with undefined being added to manual buttons.
                     $(this.target + ' div.' + this._strip_punctuation(feature) + '-btns ul.dropdown-menu').append(
-                        '<li><a href="#" data-feature="' + this._strip_punctuation(feature) + '" data-key="' + features[i] + '">' 
+                        '<li><a href="#" data-feature="' + this._strip_punctuation(feature) + '" data-key="' + features[i] + '">'
                             + features[i] + '</a></li>'
-                    ); 
+                    );
                 }
             }
 
-            $('.' + this._strip_punctuation(feature) + '-btns .dropdown-menu li a').on('click', function() {
-                var k = $(this).data('key'); 
-                var feature = $(this).data('feature');
-                var manual_feature;
-                $('.' + feature + '-btns button.btn span.title').html(k);
-                if (!manual_map.hasOwnProperty(feature)) {
-                    callback(feature, k);    
-                } else {
-                    manual_feature = manual_map[feature];
-                    manual_callback[manual_feature](k);
-                }
-                
-                return false;
-            });
+            $('.' + this._strip_punctuation(feature) + '-btns .dropdown-menu li a').on('click', dropdownLiAClick);
         }
 
         return this;
     };
 
-    return this
-}
+    return this;
+};

--- a/src/js/misc/error.js
+++ b/src/js/misc/error.js
@@ -1,7 +1,8 @@
 //call this to add a warning icon to a graph and log an error to the console
 function error(args) {
-    var error = '<i class="fa fa-x fa-exclamation-circle warning"></i>';
     console.log('ERROR : ', args.target, ' : ', args.error);
-    
-    $(args.target).find('.mg-chart-title').append(error);
+
+    $(args.target)
+        .find('.mg-chart-title')
+        .append('<i class="fa fa-x fa-exclamation-circle warning"></i>');
 }

--- a/src/js/misc/process.js
+++ b/src/js/misc/process.js
@@ -9,7 +9,7 @@ function raw_data_transformation(args) {
     if (args.chart_type === 'line') {
         var is_unnested_obj_array = (args.data[0] instanceof Object && !(args.data[0] instanceof Array));
         var is_unnested_array_of_arrays = (
-            args.data[0] instanceof Array && 
+            args.data[0] instanceof Array &&
             !(args.data[0][0] instanceof Object &&
             !(args.data[0][0] instanceof Date)));
 
@@ -34,8 +34,8 @@ function raw_data_transformation(args) {
                     return di;
                 }).filter(function(di) {
                     return di !== undefined;
-                })
-            })
+                });
+            });
         })[0];
 
         args.y_accessor = 'multiline_y_accessor';
@@ -50,7 +50,7 @@ function raw_data_transformation(args) {
         }
     }
 
-    return this
+    return this;
 }
 
 function process_line(args) {
@@ -100,7 +100,7 @@ function process_line(args) {
 
                         return false;
                     }
-                })
+                });
 
                 //if we don't have this date in our data object, add it and set it to zero
                 if (!existing_o) {
@@ -157,7 +157,7 @@ function process_histogram(args) {
             return;
         }
 
-        var hist = d3.layout.histogram()
+        var hist = d3.layout.histogram();
         if (args.bins) {
             hist = hist.bins(args.bins);
         }

--- a/src/js/misc/smoothers.js
+++ b/src/js/misc/smoothers.js
@@ -36,14 +36,15 @@ function lowess_robust(x, y, alpha, inc) {
     var _l;
     var r = [];
     var yhat = d3.mean(y);
-    for (var i = 0; i < x.length; i += 1) { r.push(1); }
+    var i;
+    for (i = 0; i < x.length; i += 1) { r.push(1); }
     _l = _calculate_lowess_fit(x,y,alpha, inc, r);
     var x_proto = _l.x;
     var y_proto = _l.y;
 
     // Now, take the fit, recalculate the weights, and re-run LOWESS using r*w instead of w.
 
-    for (var i = 0; i < 100; i += 1) {
+    for (i = 0; i < 100; i += 1) {
         r = d3.zip(y_proto, y).map(function(yi) {
             return Math.abs(yi[1] - yi[0]);
         });
@@ -112,8 +113,8 @@ function least_squares(x_, y_) {
     var x0 = yhat - beta * xhat;
 
     return {
-        x0: x0, 
-        beta: beta, 
+        x0: x0,
+        beta: beta,
         fit: function(x) {
             return x0 + x * beta;
         }
@@ -148,7 +149,7 @@ function _manhattan(x1,x2) {
 
 function _weighted_means(wxy) {
     var wsum = d3.sum(wxy.map(function(wxyi) { return wxyi.w; }));
-    
+
     return {
         xbar: d3.sum(wxy.map(function(wxyi) {
             return wxyi.w * wxyi.x;
@@ -188,13 +189,11 @@ function _weighted_least_squares(wxy) {
         x0   : ybar - beta * xbar
 
     };
-    
-    return num / denom;
 }
 
 function _calculate_lowess_fit(x, y, alpha, inc, residuals) {
     // alpha - smoothing factor. 0 < alpha < 1/
-    // 
+    //
     //
     var k = Math.floor(x.length * alpha);
 
@@ -208,7 +207,7 @@ function _calculate_lowess_fit(x, y, alpha, inc, residuals) {
     });
 
     var x_max = d3.quantile(sorted_x, 0.98);
-    var x_min = d3.quantile(sorted_x, 0.02); 
+    var x_min = d3.quantile(sorted_x, 0.02);
 
     var xy = d3.zip(x, y, residuals).sort();
 
@@ -217,7 +216,7 @@ function _calculate_lowess_fit(x, y, alpha, inc, residuals) {
     var smallest = x_min;
     var largest = x_max;
     var x_proto = d3.range(smallest, largest, size);
-    
+
     var xi_neighbors;
     var x_i, beta_i, x0_i, delta_i, xbar, ybar;
 
@@ -230,10 +229,10 @@ function _calculate_lowess_fit(x, y, alpha, inc, residuals) {
         // get k closest neighbors.
         xi_neighbors = xy.map(function(xyi) {
             return [
-                Math.abs(xyi[0] - x_i), 
-                xyi[0], 
+                Math.abs(xyi[0] - x_i),
+                xyi[0],
                 xyi[1],
-                xyi[2]]
+                xyi[2]];
         }).sort().slice(0, k);
 
         // Get the largest distance in the neighbor set.
@@ -243,18 +242,19 @@ function _calculate_lowess_fit(x, y, alpha, inc, residuals) {
 
         xi_neighbors = xi_neighbors.map(function(wxy) {
             return {
-                w : _tricube_weight(wxy[0] / delta_i) * wxy[3], 
-                x : wxy[1], 
+                w : _tricube_weight(wxy[0] / delta_i) * wxy[3],
+                x : wxy[1],
                 y  :wxy[2]
-            }});
-        
+            };
+        });
+
         // Find the weighted least squares, obviously.
         var _output = _weighted_least_squares(xi_neighbors);
 
         x0_i = _output.x0;
         beta_i = _output.beta;
 
-        // 
+        //
         y_proto.push(x0_i + beta_i * x_i);
     }
 

--- a/src/js/misc/utility.js
+++ b/src/js/misc/utility.js
@@ -56,7 +56,7 @@ var each = function(obj, iterator, context) {
     }
 
     return obj;
-}
+};
 
 function merge_with_defaults(obj) {
     // taken from underscore
@@ -66,7 +66,7 @@ function merge_with_defaults(obj) {
           if (obj[prop] === void 0) obj[prop] = source[prop];
         }
       }
-    })
+    });
 
     return obj;
 }
@@ -74,7 +74,7 @@ function merge_with_defaults(obj) {
 function number_of_values(data, accessor, value) {
     var values = data.filter(function(d) {
         return d[accessor] === value;
-    })
+    });
 
     return values.length;
 }
@@ -82,7 +82,7 @@ function number_of_values(data, accessor, value) {
 function has_values_below(data, accessor, value) {
     var values = data.filter(function(d) {
         return d[accessor] <= value;
-    })
+    });
 
     return values.length > 0;
 }
@@ -94,19 +94,21 @@ function has_too_many_zeros(data, accessor, zero_count) {
 //deep copy
 //http://stackoverflow.com/questions/728360/most-elegant-way-to-clone-a-javascript-object
 MG.clone = function(obj) {
+    var copy;
+
     // Handle the 3 simple types, and null or undefined
     if (null === obj || "object" !== typeof obj) return obj;
 
     // Handle Date
     if (obj instanceof Date) {
-        var copy = new Date();
+        copy = new Date();
         copy.setTime(obj.getTime());
         return copy;
     }
 
     // Handle Array
     if (obj instanceof Array) {
-        var copy = [];
+        copy = [];
         for (var i = 0, len = obj.length; i < len; i++) {
             copy[i] = MG.clone(obj[i]);
         }
@@ -115,7 +117,7 @@ MG.clone = function(obj) {
 
     // Handle Object
     if (obj instanceof Object) {
-        var copy = {};
+        copy = {};
         for (var attr in obj) {
             if (obj.hasOwnProperty(attr)) copy[attr] = MG.clone(obj[attr]);
         }
@@ -123,15 +125,17 @@ MG.clone = function(obj) {
     }
 
     throw new Error("Unable to copy obj! Its type isn't supported.");
-}
+};
 
 //give us the difference of two int arrays
 //http://radu.cotescu.com/javascript-diff-function/
 function arrDiff(a,b) {
-    var seen = [], diff = [];
-    for ( var i = 0; i < b.length; i++)
+    var seen = [],
+        diff = [],
+        i;
+    for (i = 0; i < b.length; i++)
         seen[b[i]] = true;
-    for ( var i = 0; i < a.length; i++)
+    for (i = 0; i < a.length; i++)
         if (!seen[a[i]])
             diff.push(a[i]);
     return diff;
@@ -199,10 +203,10 @@ function wrapText(text, width, token, tspanAttrs) {
           .attr("y", dy + "em")
           .attr(tspanAttrs || {});
 
-    while (word = words.pop()) {
+    while (!!(word = words.pop())) {
       line.push(word);
       tspan.text(line.join(" "));
-      if (width == null || tspan.node().getComputedTextLength() > width) {
+      if (width === null || tspan.node().getComputedTextLength() > width) {
         line.pop();
         tspan.text(line.join(" "));
         line = [word];


### PR DESCRIPTION
- Replaced jslint with jshint (less opinionated, more flexible, actively maintained etc.)
- `.jshintrc` Allowing functions within loops & quote-notation for objects - can switch those back on after future refactors
- declaring MG global as `window.MG` vs. old `var MG`
- jshint gulp task is now executed with each server reload, printing results to the console