### PR TITLE
Improved tween for line-chart path transitions

### DIFF
--- a/gulp/index.js
+++ b/gulp/index.js
@@ -41,6 +41,7 @@ var
     src + 'misc/process.js',
     src + 'misc/smoothers.js',
     src + 'misc/formatters.js',
+    src + 'misc/transitions.js',
     src + 'misc/utility.js',
     src + 'misc/error.js'
   ];

--- a/src/index.html
+++ b/src/index.html
@@ -38,6 +38,7 @@
     <script src='js/misc/process.js'></script>
     <script src='js/misc/smoothers.js'></script>
     <script src='js/misc/formatters.js'></script>
+    <script src='js/misc/transitions.js'></script>
     <script src='js/misc/utility.js'></script>
     <script src='js/misc/error.js'></script>
     <!-- dev end -->

--- a/src/js/charts/line.js
+++ b/src/js/charts/line.js
@@ -88,7 +88,8 @@ charts.line = function(args) {
 
             //add the area
             var $area = $(args.target).find('svg path.mg-area' + (line_id) + '-color');
-            if (args.area && !args.use_data_y_min && !args.y_axis_negative && args.data.length <= 1) {
+            var displayArea = args.area && !args.use_data_y_min && !args.y_axis_negative && args.data.length <= 1;
+            if (displayArea) {
                 //if area already exists, transition it
                 if ($area.length > 0) {
                     $(svg.node()).find('.mg-y-axis').after($area.detach());
@@ -108,13 +109,19 @@ charts.line = function(args) {
             }
 
             //add the line, if it already exists, transition the fine gentleman
-            var $existing_line = $(args.target).find('svg path.mg-main-line.mg-line' + (line_id) + '-color').first();
-            if ($existing_line.length > 0) {
-                $(svg.node()).find('.mg-y-axis').after($existing_line.detach());
-                d3.select($existing_line.get(0))
+            var existing_line = svg.select('path.mg-main-line.mg-line' + (line_id) + '-color');
+            if (!existing_line.empty()) {
+                $(svg.node()).find('.mg-y-axis').after($(existing_line.node()).detach());
+                var lineTransition = existing_line
                     .transition()
-                        .duration(updateTransitionDuration)
-                        .attr('d', line(args.data[i]));
+                    .duration(updateTransitionDuration);
+
+                if (!displayArea) {
+                    lineTransition.attrTween('d', pathTween(line(args.data[i]), 4));
+                } else {
+                    lineTransition.attr('d', line(args.data[i]));
+                }
+
             }
             else { //otherwise...
                 //if we're animating on load, animate the line from its median value

--- a/src/js/misc/transitions.js
+++ b/src/js/misc/transitions.js
@@ -1,0 +1,25 @@
+// http://bl.ocks.org/mbostock/3916621
+function pathTween(d1, precision) {
+  return function() {
+    var path0 = this,
+        path1 = path0.cloneNode(),
+        n0 = path0.getTotalLength(),
+        n1 = (path1.setAttribute("d", d1), path1).getTotalLength();
+
+    // Uniform sampling of distance based on specified precision.
+    var distances = [0], i = 0, dt = precision / Math.max(n0, n1);
+    while ((i += dt) < 1) distances.push(i);
+    distances.push(1);
+
+    // Compute point-interpolators at each distance.
+    var points = distances.map(function(t) {
+      var p0 = path0.getPointAtLength(t * n0),
+          p1 = path1.getPointAtLength(t * n1);
+      return d3.interpolate([p0.x, p0.y], [p1.x, p1.y]);
+    });
+
+    return function(t) {
+      return t < 1 ? "M" + points.map(function(p) { return p(t); }).join("L") : d1;
+    };
+  };
+}

--- a/testem.json
+++ b/testem.json
@@ -24,6 +24,7 @@
     "src/js/misc/process.js",
     "src/js/misc/smoothers.js",
     "src/js/misc/formatters.js",
+    "src/js/misc/transitions.js",
     "src/js/misc/utility.js",
     "src/js/misc/error.js",
 


### PR DESCRIPTION
Applies smoother transitions between variable-length paths on the line chart.

NB: Does not yet apply to charts which use area:true.