### PR TITLE
Fix duplicate chart title on redraw

### DIFF
--- a/src/js/common/chart_title.js
+++ b/src/js/common/chart_title.js
@@ -1,40 +1,32 @@
 function chart_title(args) {
     'use strict';
 
-    //remove the chart title if it's different than the new one
-    var currentTitle = d3.select(args.target).selectAll('.mg-chart-title');
+    var svg = d3.select(args.target);
 
-    if (!currentTitle.empty() && args.title && args.title !== currentTitle.text()) {
-        currentTitle.remove();
-    
-    } //if title hasn't been specified or if it's blank, remove the title
-    else if(!args.title || args.title === '') {
-        currentTitle.remove();
-    }
-
+    // remove the current title if it exists
+    svg.select('.mg-chart-title').remove();
 
     if (args.target && args.title) {
-        var newTitle;
         //only show question mark if there's a description
         var optional_question_mark = (args.show_tooltips && args.description)
             ? '<i class="fa fa-question-circle fa-inverse description"></i>'
             : '';
 
-        d3.select(args.target).insert('h2', ':first-child') 
+        svg.insert('h2', ':first-child')
             .attr('class', 'mg-chart-title')
             .html(args.title + optional_question_mark);
 
         //activate the question mark if we have a description
         if (args.show_tooltips && args.description) {
-            newTitle = $(args.target).find('h2.mg-chart-title');
+            var $newTitle = $(svg.node()).find('h2.mg-chart-title');
 
-            newTitle.popover({
+            $newTitle.popover({
                 html: true,
                 animation: false,
                 content: args.description,
                 trigger: 'hover',
                 placement: 'top',
-                container: newTitle
+                container: $newTitle
             });
         }
     }

--- a/tests/common/chart_title_test.js
+++ b/tests/common/chart_title_test.js
@@ -7,7 +7,7 @@ test('Chart title is updated', function() {
         data: [{'date': new Date('2014-01-01'), 'value': 12},
                {'date': new Date('2014-03-01'), 'value': 18}]
     };
-    
+
     var params2 = MG.clone(params);
     params2.title = 'bar';
 
@@ -23,7 +23,7 @@ test('Chart title is removed if title is set to blank', function() {
         data: [{'date': new Date('2014-01-01'), 'value': 12},
                {'date': new Date('2014-03-01'), 'value': 18}]
     };
-    
+
     var params2 = MG.clone(params);
     params2.title = '';
 
@@ -39,7 +39,7 @@ test('Chart title is removed if title is not set', function() {
         data: [{'date': new Date('2014-01-01'), 'value': 12},
                {'date': new Date('2014-03-01'), 'value': 18}]
     };
-    
+
     var params2 = MG.clone(params);
     delete params2.title;
 
@@ -74,4 +74,17 @@ test('When an error is set, we get an exclamation icon', function() {
 
     MG.data_graphic(params);
     ok(document.querySelector('.mg-chart-title .warning'), 'Error icon exists');
+});
+
+test('Chart title is not duplicated on redraw', function() {
+    var params = {
+        title: 'foo',
+        target: '#qunit-fixture',
+        data: [{'date': new Date('2014-01-01'), 'value': 12},
+               {'date': new Date('2014-03-01'), 'value': 18}]
+    };
+
+    MG.data_graphic(params);
+    MG.data_graphic(params);
+    equal(document.querySelectorAll('.mg-chart-title').length, 1, 'there is once chart title');
 });


### PR DESCRIPTION
Removing that early return [here](https://github.com/dandehavilland/metrics-graphics/commit/7441e281d93d34583eb7ce5a9b83d8f3e6715985#diff-b658a832cb3b8dff3a4095a026e8c3beL13) resulted in a duplicate title when redrawing an existing chart. 

That whole block can go if we just replace the title node in every case - makes this function a little nicer to read.