### PR TITLE
Add missing .mg-hover-* colors to dark demo css

### DIFF
--- a/examples/css/metricsgraphics-demo-dark.css
+++ b/examples/css/metricsgraphics-demo-dark.css
@@ -106,7 +106,15 @@ li {
     stroke: #ffd300;
 }
 
+.mg-hover-line1-color {
+    stroke: #ffd300;
+}
+
 .mg-line2-color {
+    stroke: #18ff00;
+}
+
+.mg-hover-line2-color {
     stroke: #18ff00;
 }
 
@@ -114,11 +122,23 @@ li {
     stroke: #f57070;
 }
 
+.mg-hover-line3-color {
+    stroke: #f57070;
+}
+
 .mg-line4-color {
     stroke: #f8b128;
 }
 
+.mg-hover-line4-color {
+    stroke: #f8b128;
+}
+
 .mg-line5-color {
+    stroke: #f7f7f7;
+}
+
+.mg-hover-line5-color {
     stroke: #f7f7f7;
 }
 

--- a/examples/js/main.js
+++ b/examples/js/main.js
@@ -114,7 +114,7 @@
         // add a line chart that has a few observations
         MG.data_graphic({
             title: "Few Observations",
-            description: "We sometimes have only a few observations. By setting <i>missing_is_zero: true</i>, missing values for a time-series will be interpreted as zeros. In this example, we've overridden the rollover callback to show 'no date' for missing observations and have set the <i>min_x</i> and <i>max_x</i> options in order to expand the date range.",
+            description: "We sometimes have only a few observations. By setting <i>missing_is_zero: true</i>, missing values for a time-series will be interpreted as zeros. In this example, we've overridden the rollover callback to show 'no data' for missing observations and have set the <i>min_x</i> and <i>max_x</i> options in order to expand the date range.",
             data: data,
             interpolate: 'basic',
             missing_is_zero: true,


### PR DESCRIPTION
This only seems to show up on the `aggregate_rollover` tooltip demo. The default line-1 color remains in the tooltip, whereas it changes to yellow for the actual graph. Screenshot attached.

![hover-css-screenshot](https://cloud.githubusercontent.com/assets/170997/6333924/1828e93e-bb5f-11e4-99d9-648cff02be83.png)
