### PR TITLE
Fix "Uncaught ReferenceError: globals is not defined" for linked point c...

### DIFF
--- a/src/js/charts/point.js
+++ b/src/js/charts/point.js
@@ -122,8 +122,8 @@ charts.point = function(args) {
             }
 
             //trigger mouseover on all points for this class name in .linked charts
-            if (args.linked && !globals.link) {
-                globals.link = true;
+            if (args.linked && !MG.globals.link) {
+                MG.globals.link = true;
 
                 //trigger mouseover on matching point in .linked charts
                 d3.selectAll('.mg-voronoi .path-' + i)
@@ -162,8 +162,8 @@ charts.point = function(args) {
         var svg = mg_get_svg_child_of(args.target);
 
         return function(d,i) {
-            if (args.linked && globals.link) {
-                globals.link = false;
+            if (args.linked && MG.globals.link) {
+                MG.globals.link = false;
 
                 d3.selectAll('.mg-voronoi .path-' + i)
                     .each(function() {


### PR DESCRIPTION
This is easy to reproduce. In the interactive demo page, just add the following at the end:

```javascript
  linked: true,
  chart_type: 'point'
```

Then highlight over the graph. In the JavaScript console, you'll see:

```
Uncaught ReferenceError: globals is not defined
```
