### PR TITLE
Improved target reference generation

### DIFF
--- a/src/js/charts/line.js
+++ b/src/js/charts/line.js
@@ -129,7 +129,7 @@
 
                         confidenceBand
                             .attr('d', confidence_area(args.data[i]))
-                            .attr('clip-path', 'url(#mg-plot-window-'+ mg_strip_punctuation(args.target)+')');
+                            .attr('clip-path', 'url(#mg-plot-window-'+ mg_target_ref(args.target)+')');
                     }
 
                     //add the area
@@ -144,12 +144,12 @@
                                 .transition()
                                     .duration(updateTransitionDuration)
                                     .attr('d', area(args.data[i]))
-                                    .attr('clip-path', 'url(#mg-plot-window-'+ mg_strip_punctuation(args.target)+')');
+                                    .attr('clip-path', 'url(#mg-plot-window-'+ mg_target_ref(args.target)+')');
                         } else { //otherwise, add the area
                             svg.append('path')
                                 .attr('class', 'mg-main-area ' + 'mg-area' + (line_id) + '-color')
                                 .attr('d', area(args.data[i]))
-                                .attr('clip-path', 'url(#mg-plot-window-' + mg_strip_punctuation(args.target) + ')');
+                                .attr('clip-path', 'url(#mg-plot-window-' + mg_target_ref(args.target) + ')');
                         }
                     } else if (!areas.empty()) {
                         areas.remove();
@@ -182,12 +182,12 @@
                                 .transition()
                                     .duration(1000)
                                     .attr('d', line(args.data[i]))
-                                    .attr('clip-path', 'url(#mg-plot-window-' + mg_strip_punctuation(args.target) + ')');
+                                    .attr('clip-path', 'url(#mg-plot-window-' + mg_target_ref(args.target) + ')');
                         } else { //or just add the line
                             svg.append('path')
                                 .attr('class', 'mg-main-line ' + 'mg-line' + (line_id) + '-color')
                                 .attr('d', line(args.data[i]))
-                                .attr('clip-path', 'url(#mg-plot-window-' + mg_strip_punctuation(args.target) + ')');
+                                .attr('clip-path', 'url(#mg-plot-window-' + mg_target_ref(args.target) + ')');
                         }
                     }
 

--- a/src/js/common/init.js
+++ b/src/js/common/init.js
@@ -80,7 +80,7 @@ function init(args) {
     svg.append('defs')
         .attr('class', 'mg-clip-path')
         .append('clipPath')
-            .attr('id', 'mg-plot-window-' + mg_strip_punctuation(args.target))
+            .attr('id', 'mg-plot-window-' + mg_target_ref(args.target))
         .append('svg:rect')
             .attr('x', args.left)
             .attr('y', args.top)

--- a/src/js/misc/utility.js
+++ b/src/js/misc/utility.js
@@ -28,7 +28,7 @@ function is_array(thing){
 }
 
 function is_function(thing){
-    return Object.prototype.toString.call(thing) === '[object Function]';   
+    return Object.prototype.toString.call(thing) === '[object Function]';
 }
 
 function is_empty_array(thing){
@@ -36,7 +36,7 @@ function is_empty_array(thing){
 }
 
 function is_object(thing){
-    return Object.prototype.toString.call(thing) === '[object Object]';   
+    return Object.prototype.toString.call(thing) === '[object Object]';
 }
 
 function is_array_of_arrays(data){
@@ -93,7 +93,7 @@ function preventVerticalOverlap(labels, args) {
         label_i = d3.select(labels[i]).text();
 
         for (var j = 0; j < labels.length; j ++) {
-            label_j = d3.select(labels[j]).text(); 
+            label_j = d3.select(labels[j]).text();
             overlap_amount = isVerticallyOverlapping(labels[i], labels[j]);
 
             if (overlap_amount !== false && label_i !== label_j) {
@@ -127,7 +127,7 @@ function isHorizontallyOverlapping(element, labels) {
 
         //check to see if this label overlaps with any of the other labels
         var sibling_bbox = labels[i].getBoundingClientRect();
-        if (element_bbox.top === sibling_bbox.top && 
+        if (element_bbox.top === sibling_bbox.top &&
                 !(sibling_bbox.left > element_bbox.right || sibling_bbox.right < element_bbox.left)
             ) {
             return true;
@@ -152,12 +152,11 @@ function mg_strip_punctuation(s) {
     if (typeof(s) == 'string') {
         processed_s = s;
     } else {
-        // args.target is 
         if (s.id != '') {
             processed_s = s.id;
-        } else if (args.target.className != '') {
+        } else if (s.className != '') {
             processed_s = s.className;
-        } else if (args.target.nodeName !='') {
+        } else if (s.nodeName !='') {
             processed_s = s.nodeName;
         } else {
             console.warn('The specified target element ' + s + ' has no unique attributes.');

--- a/src/js/misc/utility.js
+++ b/src/js/misc/utility.js
@@ -146,27 +146,37 @@ function mg_flatten_array(arr) {
     return flat_data.concat.apply(flat_data, arr);
 }
 
-function mg_strip_punctuation(s) {
-    var processed_s;
-
-    if (typeof(s) == 'string') {
-        processed_s = s;
-    } else {
-        if (s.id != '') {
-            processed_s = s.id;
-        } else if (s.className != '') {
-            processed_s = s.className;
-        } else if (s.nodeName !='') {
-            processed_s = s.nodeName;
-        } else {
-            console.warn('The specified target element ' + s + ' has no unique attributes.');
-        }
+function mg_next_id() {
+    if (typeof MG._next_elem_id === 'undefined') {
+        MG._next_elem_id = 0;
     }
 
-    var punctuationless = processed_s.replace(/[^a-zA-Z0-9 _]+/g, '');
-    var finalString = punctuationless.replace(/ +?/g, "");
+    return 'mg-'+(MG._next_elem_id++);
+}
 
-    return finalString;
+function mg_target_ref(target) {
+    if (typeof target === 'string') {
+        return mg_normalize(target);
+
+    } else if (target instanceof HTMLElement) {
+        target_ref = target.getAttribute('data-mg-uid');
+        if (!target_ref) {
+            target_ref = mg_next_id();
+            target.setAttribute('data-mg-uid', target_ref);
+        }
+
+        return target_ref;
+
+    } else {
+        console.warn('The specified target should be a string or an HTMLElement.', target);
+        return mg_normalize(target);
+    }
+}
+
+function mg_normalize(string) {
+    return string
+        .replace(/[^a-zA-Z0-9 _-]+/g, '')
+        .replace(/ +?/g, '');
 }
 
 function get_pixel_dimension(target, dimension) {

--- a/tests/misc/utility_test.js
+++ b/tests/misc/utility_test.js
@@ -3,7 +3,7 @@ module('utility');
 test('MG.convert.date', function() {
     var data = [{'date': '2014-01-01', 'value': 12},
                {'date': '2014-03-01', 'value': 18}];
-    
+
     MG.convert.date(data, 'date');
     equal($.type(data[0].date), 'date', 'First date is of type date');
     equal($.type(data[0].date), 'date', 'Second date is of type date');
@@ -12,7 +12,7 @@ test('MG.convert.date', function() {
 test('MG.convert.date with an alternative timestamp style', function() {
     var data = [{'date': '2014-20-12', 'value': 12},
                {'date': '2014-21-12', 'value': 18}];
-    
+
     MG.convert.date(data, 'date', '%Y-%d-%m');
     equal($.type(data[0].date), 'date', 'First date is of type date');
     equal($.type(data[0].date), 'date', 'Second date is of type date');
@@ -21,7 +21,7 @@ test('MG.convert.date with an alternative timestamp style', function() {
 test('MG.convert.number', function() {
     var data = [{'date': '2014-20-12', 'value': '12'},
                {'date': '2014-21-12', 'value': '18'}];
-    
+
     MG.convert.number(data, 'value');
     equal($.type(data[0].value), 'number', 'First value is a number');
     equal($.type(data[0].value), 'number', 'Second value is a number');
@@ -38,31 +38,8 @@ test('mg_get_svg_child_of', function(){
 });
 
 
-module('Utility Functions');
-
-
-////////////////////////////////////////////////////
-//              Ch. 1 - MG.convert.               //
-////////////////////////////////////////////////////
-
-/*var datapoint1 = [{date: '2014-03-01', value: 6}];
-var datapoint2 = [{date: 232243442, value: 6}];
-
-test('Date works as intended', function() {
-  var transformed = MG.convert.date(datapoint1, 'date');
-  var out = d3.time.format('%Y-%m-%d')('2014-03-01');
-  equal(datapoint[0].date, out, 'both values should be new Date obj set at 2014-03-01');
+test('mg_target_ref', function() {
+    var chart_area2 = document.createElement('div');
+    mg_target_ref(chart_area2);
+    ok(chart_area2.getAttribute('data-mg-uid').match(/mg-[\d]/), 'applies generated ID to DOM element');
 });
-
-test('custom date', function() {
-  var transformed = MG.convert.date(datapoint1, 'date', '%m-%d');
-  var out = d3.time.format('%m-%d')('2014-03-01');
-  equal(datapoint[0].date, out, 'both values should be new Date obj set at 2014-03-01');
-});
-
-test('invalid date', function() {
-  var transformed = MG.convert.date(datapoint1, 'date', '%m-%d');
-  var out = d3.time.format('%m-%d')('2014-03-01');
-  equal(datapoint[0].date, out, 'both values should be new Date obj set at 2014-03-01');
-});
-*/


### PR DESCRIPTION
This fixes #421 which is an issue using a class selector as the target when switching from a missing chart to a line chart. I'm not sure if it affected any other use case.

All tests are green. I also wrote a test case for this scenario, but I'm not sure what I should assert.
```js
test('Can change from missing chart to line chart using class selector as target', function() {

    var qunit_fixture = document.getElementById('qunit-fixture');
    var chart_area = document.createElement('div');
    chart_area.className = 'chart-area';
    qunit_fixture.appendChild(chart_area);

    var params = {
        target: document.querySelector('.chart-area'),
        chart_type: 'missing-data',
        missing_text: 'In an astral plane that was never meant to fly...'
    };

    MG.data_graphic(params);

    params.data = [{'date': new Date('2014-01-01'), 'value': 12},
                   {'date': new Date('2014-03-01'), 'value': 18}];
    params.chart_type = 'line';

    MG.data_graphic(params);
    // should I assert anything here?
});
```