### PR TITLE
Adding bar label rotation

### DIFF
--- a/src/js/charts/bar.js
+++ b/src/js/charts/bar.js
@@ -377,7 +377,11 @@
         height: 500,
         top: 20,
         bar_height: 20,
-        left: 70
+        left: 70,
+        truncate_x_labels: true,
+        truncate_y_labels: true,
+        x_label_rotation: 0,
+        y_label_rotation: 0
     };
 
     MG.register('bar', barChart, defaults);

--- a/src/js/common/x_axis.js
+++ b/src/js/common/x_axis.js
@@ -11,7 +11,7 @@ function x_rug(args) {
     //         all_data.push(args.data[i][j]);
     //     }
     // }
-    
+
     var rug = svg.selectAll('line.mg-x-rug').data(all_data);
 
     //set the attributes that do not change after initialization, per
@@ -146,11 +146,24 @@ function x_axis_categorical(args) {
         .attr('text-anchor', 'middle')
         .text(String);
 
-    labels.each(function(d, idx) {
-        var elem = this,
-            width = args.scales.X.rangeBand();
-        truncate_text(elem, d, width);
-    });
+    if (args.rotate_x_labels) {
+        labels.attr({
+            dy: 0,
+            'text-anchor': 'end',
+            transform: function() {
+                var elem = d3.select(this);
+                return 'rotate('+args.rotate_x_labels+' '+elem.attr('x')+','+elem.attr('y')+')';
+            }
+        });
+    }
+
+    if (args.truncate_x_labels) {
+        labels.each(function(d, idx) {
+            var elem = this,
+                width = args.scales.X.rangeBand();
+            truncate_text(elem, d, width);
+        });
+    }
 
     return this;
 }
@@ -495,8 +508,8 @@ function mg_find_min_max_x(args) {
         });
     }
     //if data set is of length 1, expand the range so that we can build the x-axis
-    if (min_x === max_x 
-            && !(args.min_x && args.max_x) 
+    if (min_x === max_x
+            && !(args.min_x && args.max_x)
         ) {
         if (min_x instanceof Date) {
             var yesterday = MG.clone(min_x).setDate(min_x.getDate() - 1);

--- a/src/js/common/y_axis.js
+++ b/src/js/common/y_axis.js
@@ -325,7 +325,7 @@ function y_axis_categorical(args) {
         return this;
     }
 
-    g.selectAll('text').data(args.categorical_variables).enter().append('svg:text')
+    var labels = g.selectAll('text').data(args.categorical_variables).enter().append('svg:text')
         .attr('x', args.left)
         .attr('y', function(d) {
             return args.scales.Y(d) + args.scales.Y.rangeBand() / 2
@@ -334,6 +334,16 @@ function y_axis_categorical(args) {
         .attr('dy', '.35em')
         .attr('text-anchor', 'end')
         .text(String);
+
+    if (args.rotate_y_labels) {
+        labels.attr({
+            dy: 0,
+            transform: function() {
+                var elem = d3.select(this);
+                return 'rotate('+args.rotate_y_labels+' '+elem.attr('x')+','+elem.attr('y')+')';
+            }
+        });
+    }
 
     return this;
 }


### PR DESCRIPTION
This PR provides a way to handle extended labels for the bar chart. 

My first thought was that this belongs in an extension, but since we have (experimental) support for vertical bar charts anyway, it probably should be in the core. @almossawi, @hamilton: any thoughts?

Options to change angle of rotation, also applies to Y labels.

![screen-shot-2015-05-22-at-16 53 14](https://cloud.githubusercontent.com/assets/95854/7773222/5b1fb9f0-00a3-11e5-84eb-f7806903a66f.png)


