### PR TITLE
Only try to add ticks if there is variation in the y-axis

### DIFF
--- a/src/js/common/y_axis.js
+++ b/src/js/common/y_axis.js
@@ -251,13 +251,21 @@ function y_axis(args) {
         });
     }
 
-    var last_i = scale_ticks.length - 1;
-    if (!args.x_extended_ticks && !args.y_extended_ticks) {
-        g.append('line')
-            .attr('x1', args.left)
-            .attr('x2', args.left)
-            .attr('y1', args.scales.Y(scale_ticks[0]).toFixed(2))
-            .attr('y2', args.scales.Y(scale_ticks[last_i]).toFixed(2));
+    var tick_length = scale_ticks.length;
+    if (!args.x_extended_ticks && !args.y_extended_ticks && tick_length) {
+      var y1scale, y2scale;
+      if (tick_length){
+        y1scale = args.scales.Y(scale_ticks[0]).toFixed(2);
+        y2scale = args.scales.Y(scale_ticks[tick_length - 1]).toFixed(2);
+      } else {
+        y1scale = 0;
+        y2scale = 0;
+      }
+      g.append('line')
+          .attr('x1', args.left)
+          .attr('x2', args.left)
+          .attr('y1', y1scale)
+          .attr('y2', y2scale);
     }
 
     //add y ticks


### PR DESCRIPTION
Without this zero y variation gives
`Error: Invalid value for <line> attribute y2="NaN"`

I'm sorry I've not worked out how to get a test for this.