### PR TITLE
missing-data chart with full_width: true doesn't react properly on window resize

### DIFF
--- a/src/js/charts/missing.js
+++ b/src/js/charts/missing.js
@@ -114,6 +114,13 @@
                 .attr('text-anchor', 'middle')
                 .text(args.missing_text);
 
+            this.windowListeners();
+
+            return this;
+        };
+
+        this.windowListeners = function() {
+            mg_window_listeners(this.args);
             return this;
         };
 


### PR DESCRIPTION
I use code snippet below with full_width: true. When I resize browser window then graph doesn't change their size.

```
            MG.data_graphic({
                title: "Missing Data",
                description: "This is an example of a graphic whose data is currently missing. We've also set the error option, which appends an error icon to the title and logs an error to the browser's console.",
                error: 'This data is blocked by Lorem Ipsum. Get your **** together, Ipsum.',
                chart_type: 'missing-data',
                missing_text: 'This is an example of a missing chart',
                target: '#graph-section',
                full_width: true,
                height: 200
            });
```
