### PR TITLE
Attach the window resize handler in a removable way

### DIFF
--- a/src/js/common/window_listeners.js
+++ b/src/js/common/window_listeners.js
@@ -1,3 +1,20 @@
+function window_resize_listener() {
+  var svg = d3.select(args.target).select('svg');
+
+  var aspect = svg.attr('width') !== 0
+      ? (svg.attr('height') / svg.attr('width'))
+      : 0;
+
+  var newWidth = get_width(args.target);
+
+  svg.attr('width', newWidth);
+  svg.attr('height', aspect * newWidth);
+}
+
+MG.remove_window_listeners = function mg_remove_window_listeners() {
+  window.removeEventListener('resize', window_resize_listener, false);
+};
+
 function mg_window_listeners(args) {
   mg_if_aspect_ratio_resize_svg(args);
 }
@@ -5,21 +22,6 @@ function mg_window_listeners(args) {
 function mg_if_aspect_ratio_resize_svg(args) {
   // have we asked the svg to fill a div, if so resize with div
   if (args.full_width || args.full_height) {
-    if (window.onresize === null) {
-      window.onresize = window_listener;
-    }
-  }
-
-  function window_listener() {
-    var svg = d3.select(args.target).select('svg');
-
-    var aspect = svg.attr('width') !== 0
-        ? (svg.attr('height') / svg.attr('width'))
-        : 0;
-
-    var newWidth = get_width(args.target);
-
-    svg.attr('width', newWidth);
-    svg.attr('height', aspect * newWidth);
+    window.addEventListener('resize', window_resize_listener, false);
   }
 }


### PR DESCRIPTION
Window listeners should be added in a safe and removable way so that they can be cleaned up when no longer wanted.  Also, add an `MG` method to remove window listeners in this situation.

Addresses #544