### PR TITLE
Fix

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -14,7 +14,7 @@ indent_size = 4
 
 [*.js]
 indent_style = space
-indent_size = 4
+indent_size = 2
 
 [*.hbs]
 indent_style = space

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ other/htaccess.txt
 .DS_Store
 
 bare.html
+/.svn
+/.idea
+/*.iml

--- a/src/js/charts/point.js
+++ b/src/js/charts/point.js
@@ -161,9 +161,9 @@
       var svg = mg_get_svg_child_of(args.target);
 
       return function(d,i) {
-          args.hoverLayer.html("");
+        args.hoverLayer.html("");
 
-          if (args.linked && MG.globals.link) {
+        if (args.linked && MG.globals.link) {
           MG.globals.link = false;
 
           d3.selectAll('.mg-voronoi .path-' + i)

--- a/src/js/charts/point.js
+++ b/src/js/charts/point.js
@@ -14,6 +14,11 @@
 
       this.mainPlot();
       this.markers();
+
+      //insert a client layers for drawing more wonderful things
+      args.selectLayer = mg_get_svg_child_of(args.target).append("g");
+      args.hoverLayer = mg_get_svg_child_of(args.target).append("g");
+
       this.rollover();
       this.windowListeners();
 
@@ -147,7 +152,7 @@
         }
 
         if (args.mouseover) {
-          args.mouseover(d, i);
+          args.mouseover(d.point, i);
         }
       };
     };
@@ -156,7 +161,9 @@
       var svg = mg_get_svg_child_of(args.target);
 
       return function(d,i) {
-        if (args.linked && MG.globals.link) {
+          args.hoverLayer.html("");
+
+          if (args.linked && MG.globals.link) {
           MG.globals.link = false;
 
           d3.selectAll('.mg-voronoi .path-' + i)


### PR DESCRIPTION
1. Added two layers for potential use by caller (client).  Example [1] which shows the added hover circle for more clarity; clicking shows the `selectLayer`.  I imagine you can add cross-hairs or tooltips to this layer.
2. I believe the code should read ` args.mouseover(d.point, i);` because the `d` is the voronoi path, which should be a hidden implementation concern.
3. The hover layer is special in that it is always cleared if there is movement.

[1] http://people.mozilla.org/~klahnakoski/MoBuildbotTimings/Builds-Detail.html#sampleMax=2016-02-04&sampleMin=2016-01-25&product=Firefox&type=Standard&platform=Linux64