### PR TITLE
Single window resize listener for all targets with automatic cleanup (fixes #544)

### DIFF
--- a/src/js/common/window_listeners.js
+++ b/src/js/common/window_listeners.js
@@ -1,25 +1,83 @@
-function mg_window_listeners(args) {
-  mg_if_aspect_ratio_resize_svg(args);
-}
+function MG_WindowResizeTracker() {
+  var targets = [];
 
-function mg_if_aspect_ratio_resize_svg(args) {
-  // have we asked the svg to fill a div, if so resize with div
-  if (args.full_width || args.full_height) {
-    if (window.onresize === null) {
-      window.onresize = window_listener;
-    }
+  var Observer;
+  if (typeof MutationObserver !== "undefined") {
+    Observer = MutationObserver;
+  } else if (typeof WebKitMutationObserver !== "undefined") {
+    Observer = WebKitMutationObserver;
   }
 
   function window_listener() {
-    var svg = d3.select(args.target).select('svg');
+    targets.forEach(function (target) {
+      var svg = d3.select(target).select('svg');
+      
+      if (!svg.empty()) {
+        var aspect = svg.attr('width') !== 0
+          ? (svg.attr('height') / svg.attr('width'))
+          : 0;
+        
+        var newWidth = get_width(target);
+        
+        svg.attr('width', newWidth);
+        svg.attr('height', aspect * newWidth);
+      }
+    });
+  }
 
-    var aspect = svg.attr('width') !== 0
-        ? (svg.attr('height') / svg.attr('width'))
-        : 0;
+  function remove_target(target) {
+    var index = targets.indexOf(target);
+    if (index !== -1) {
+      targets.splice(index, 1);
+    }
+    
+    if (targets.length === 0) {
+      window.removeEventListener('resize', window_listener, true);
+    }
+  }
 
-    var newWidth = get_width(args.target);
+  return {
+    add_target: function(target) {
+      if (targets.length === 0) {
+        window.addEventListener('resize', window_listener, true);
+      }
+      
+      if (targets.indexOf(target) === -1) {
+        targets.push(target);
 
-    svg.attr('width', newWidth);
-    svg.attr('height', aspect * newWidth);
+        if (Observer) {
+          var observer = new Observer(function (mutations) {
+            var targetNode = d3.select(target).node();
+
+            if (!targetNode || mutations.some(
+              function (mutation) {
+                for (var i = 0; i < mutation.removedNodes.length; i++) {
+                  if (mutation.removedNodes[i] === targetNode) {
+                    return true;
+                  }
+                }
+              })) {
+              observer.disconnect();
+              remove_target(target);  
+            }
+          });
+          
+          observer.observe(d3.select(target).node().parentNode, {childList: true});
+        }
+      }
+    }
+  };
+}
+
+var mg_window_resize_tracker = new MG_WindowResizeTracker();
+
+function mg_window_listeners(args) {
+  mg_if_aspect_ratio_resize_svg(args);
+}
+  
+function mg_if_aspect_ratio_resize_svg(args) {
+  // have we asked the svg to fill a div, if so resize with div
+  if (args.full_width || args.full_height) {
+    mg_window_resize_tracker.add_target(args.target);
   }
 }

--- a/tests/common/resize_test.js
+++ b/tests/common/resize_test.js
@@ -1,0 +1,44 @@
+module('resize');
+
+test("Resize does not leak listeners", function () {
+  // Instrument window event listener methods
+  var realWindowAddEventListener = window.addEventListener;
+  var realWindowRemoveEventListener = window.removeEventListener;
+  var resizeListeners = [];
+  
+  window.addEventListener = function () {
+    if (arguments[0] === 'resize' && resizeListeners.indexOf(arguments[1]) === -1) {
+      resizeListeners.push(arguments[1]);
+    }
+    realWindowAddEventListener.apply(this, arguments);
+  }
+
+  window.removeEventListener = function () {
+    if (arguments[0] === 'resize') {
+      var index = resizeListeners.indexOf(arguments[1]);
+      if (index !== -1) {
+        resizeListeners.splice(index, 1);
+      }
+    }
+    realWindowRemoveEventListener.apply(this, arguments);
+  }
+    
+  var params = {
+    target: '#qunit-fixture',
+    full_width: true,
+    data: [{'date': new Date('2014-11-01'), 'value': 12},
+      {'date': new Date('2014-11-02'), 'value': 18}],
+    height: 100
+  };
+  MG.data_graphic(params);
+  var listenerCountAfterOne = resizeListeners.length;
+  const REPEAT_CREATE = 20;  
+  for (var i = 0; i < REPEAT_CREATE; i++) {
+    MG.data_graphic(params);
+  }
+  equal(resizeListeners.length, listenerCountAfterOne, "Listener count constant after chart recreated " + REPEAT_CREATE + " times");
+
+  // Restore default methods
+  window.addEventListener = realWindowAddEventListener;
+  window.removeEventListener = realWindowRemoveEventListener;
+});


### PR DESCRIPTION
Instead of creating one listener per target or overwriting `onresize`, the approach in this fix is to add a single listener which checks a list of target elements. On modern browsers that support MutationObserver, target elements are automatically removed from the list when destroyed and the listener is automatically removed when the target element list becomes empty.

On browsers that do not support MutationObserver (IE 10 and under), this fix mitigates #544 by adding a check in the resize listener to skip elements that no longer exist and by keeping the leak proportional to the number of unique elements observed (i.e., re-renders on the same element do not add a new listener every time.)

A unit test for the resize listener leak is provided.