### PR TITLE
Fixing disappearing point for single data point series in aggregate graph.

### DIFF
--- a/dist/metricsgraphics.js
+++ b/dist/metricsgraphics.js
@@ -3844,6 +3844,7 @@ MG.button_layout = function(target) {
 
   function mg_update_rollover_circle (args, svg, d) {
     if (args.aggregate_rollover && args.data.length > 1) {
+      console.log(args.data.length.toString());
       // hide the circles in case a non-contiguous series is present
       svg.selectAll('circle.mg-line-rollover-circle')
         .style('opacity', 0);

--- a/dist/metricsgraphics.js
+++ b/dist/metricsgraphics.js
@@ -3844,7 +3844,6 @@ MG.button_layout = function(target) {
 
   function mg_update_rollover_circle (args, svg, d) {
     if (args.aggregate_rollover && args.data.length > 1) {
-      console.log(args.data.length.toString());
       // hide the circles in case a non-contiguous series is present
       svg.selectAll('circle.mg-line-rollover-circle')
         .style('opacity', 0);
@@ -3927,9 +3926,10 @@ MG.button_layout = function(target) {
   }
 
   function mg_remove_active_data_points_for_aggregate_rollover (args, svg) {
-    if (args.data[0].length > 1) {
-      svg.selectAll('circle.mg-line-rollover-circle').style('opacity', 0);
-    }
+    svg.selectAll('circle.mg-line-rollover-circle').filter(function (circle) {
+      return circle.length > 1;
+    })
+    .style('opacity', 0);
   }
 
   function mg_remove_active_data_points_for_generic_rollover (args, svg, d) {

--- a/dist/metricsgraphics.js
+++ b/dist/metricsgraphics.js
@@ -3927,7 +3927,9 @@ MG.button_layout = function(target) {
   }
 
   function mg_remove_active_data_points_for_aggregate_rollover (args, svg) {
-    svg.selectAll('circle.mg-line-rollover-circle').style('opacity', 0);
+    if (args.data[0].length > 1) {
+      svg.selectAll('circle.mg-line-rollover-circle').style('opacity', 0);
+    }
   }
 
   function mg_remove_active_data_points_for_generic_rollover (args, svg, d) {

--- a/src/js/charts/line.js
+++ b/src/js/charts/line.js
@@ -625,6 +625,7 @@
 
   function mg_update_rollover_circle (args, svg, d) {
     if (args.aggregate_rollover && args.data.length > 1) {
+      console.log(args.data.length.toString());
       // hide the circles in case a non-contiguous series is present
       svg.selectAll('circle.mg-line-rollover-circle')
         .style('opacity', 0);

--- a/src/js/charts/line.js
+++ b/src/js/charts/line.js
@@ -625,7 +625,6 @@
 
   function mg_update_rollover_circle (args, svg, d) {
     if (args.aggregate_rollover && args.data.length > 1) {
-      console.log(args.data.length.toString());
       // hide the circles in case a non-contiguous series is present
       svg.selectAll('circle.mg-line-rollover-circle')
         .style('opacity', 0);
@@ -708,9 +707,10 @@
   }
 
   function mg_remove_active_data_points_for_aggregate_rollover (args, svg) {
-    if (args.data[0].length > 1) {
-      svg.selectAll('circle.mg-line-rollover-circle').style('opacity', 0);
-    }
+      svg.selectAll('circle.mg-line-rollover-circle').filter(function (circle) {
+        return circle.length > 1;
+      })
+      .style('opacity', 0);
   }
 
   function mg_remove_active_data_points_for_generic_rollover (args, svg, d) {

--- a/src/js/charts/line.js
+++ b/src/js/charts/line.js
@@ -708,7 +708,9 @@
   }
 
   function mg_remove_active_data_points_for_aggregate_rollover (args, svg) {
-    svg.selectAll('circle.mg-line-rollover-circle').style('opacity', 0);
+    if (args.data[0].length > 1) {
+      svg.selectAll('circle.mg-line-rollover-circle').style('opacity', 0);
+    }
   }
 
   function mg_remove_active_data_points_for_generic_rollover (args, svg, d) {


### PR DESCRIPTION
I noticed that when an aggregate graph had single point lines, it occasionally would remove the point from visibility after mouseover. I have put in a simple filter to avoid setting the opacity of rollover circles to 0 when then length of the data series is 1.