### PR TITLE
Added react component to the gallery in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ Feel free to add your addons and websites to this list.
 * [R package (htmlwidget)](https://github.com/hrbrmstr/metricsgraphics)
 * [Python library - using Pyxley](http://multithreaded.stitchfix.com/blog/2015/07/16/pyxley)
 * [Angular directive](https://github.com/elmarquez/angular-metrics-graphics)
+* [React component](https://github.com/cf/react-metrics-graphics)
 
 ## License
 


### PR DESCRIPTION
Added a link to a [React component](https://github.com/cf/react-metrics-graphics) that wraps MetricsGraphics.js.

See an example of the component in action here:
[https://cf.github.io/react-metrics-graphics/](https://cf.github.io/react-metrics-graphics/)
