### PR TITLE
Allow markers to be on the edge of the graph.

### DIFF
--- a/src/js/common/markers.js
+++ b/src/js/common/markers.js
@@ -9,7 +9,7 @@ function mg_remove_existing_markers(svg) {
 
 function mg_in_range(args) {
   return function(d) {
-    return (args.scales.X(d[args.x_accessor]) > mg_get_plot_left(args)) && (args.scales.X(d[args.x_accessor]) < mg_get_plot_right(args));
+    return (args.scales.X(d[args.x_accessor]) >= mg_get_plot_left(args)) && (args.scales.X(d[args.x_accessor]) <= mg_get_plot_right(args));
   };
 }
 

--- a/tests/common/markers_test.js
+++ b/tests/common/markers_test.js
@@ -25,7 +25,27 @@ test('Markers that lie outside the visible range are excluded', function() {
             'date': new Date('2014-02-01'),
             'label': '1st Milestone'
         }, {
-            'date': new Date('2014-02-02'),
+            'date': new Date('2014-02-03'),
+            'label': '2nd Milestone'
+        }];
+
+    var params = {
+        target: '#qunit-fixture',
+        data: [{'date': new Date('2014-02-02'), 'value': 12},
+               {'date': new Date('2014-03-01'), 'value': 18}],
+        markers: markers
+    };
+
+    MG.data_graphic(params);
+    equal(document.querySelectorAll(params.target + ' .mg-markers line').length, 1, 'One marker added');
+});
+
+test('Markers that lie at the edge of the visible range are included', function() {
+    var markers = [{
+            'date': new Date('2014-02-01'),
+            'label': '1st Milestone'
+        }, {
+            'date': new Date('2014-03-01'),
             'label': '2nd Milestone'
         }];
 
@@ -37,7 +57,7 @@ test('Markers that lie outside the visible range are excluded', function() {
     };
 
     MG.data_graphic(params);
-    equal(document.querySelectorAll(params.target + ' .mg-markers line').length, 1, 'One marker added');
+    equal(document.querySelectorAll(params.target + ' .mg-markers line').length, markers.length, 'Two markers added');
 });
 
 test('All baselines are added', function() {


### PR DESCRIPTION
Possible fix for issue #719
It works for me in a quick test with a line graph. But what are the ramifications of allowing markers on the edge of the data plot area for all sorts of graph types?
