### PR TITLE
Server rendering enabled via MG.use_virtual_element

### DIFF
--- a/gulp/index.js
+++ b/gulp/index.js
@@ -48,6 +48,7 @@ var
     src + 'misc/smoothers.js',
     src + 'misc/formatters.js',
     src + 'misc/transitions.js',
+    src + 'misc/server.js',
     src + 'misc/error.js'
   ];
 

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "d3": "^4"
   },
   "peerDependencies": {
+    "jsdom": "^9.8.3",
     "jquery": ">=1.11.1"
   },
   "devDependencies": {

--- a/src/js/MG.js
+++ b/src/js/MG.js
@@ -1,1 +1,1 @@
-window.MG = {version: '2.10.1'};
+(typeof window === 'undefined' ? global : window).MG = {version: '2.10.1'};

--- a/src/js/misc/server.js
+++ b/src/js/misc/server.js
@@ -1,0 +1,43 @@
+function use_virtual_element(fn, jsdom_instance) {
+  var jsdom = jsdom_instance || jsdom;
+  if (typeof jsdom === 'undefined') {
+    (console.error || console.log)('jsdom could not be found.');
+    return;
+  }
+
+  var global_scope = typeof window === 'undefined' ? global : window;
+  var virtual_element_id = 'virtual_elem';
+
+  // inspired by: https://bl.ocks.org/tomgp/c99a699587b5c5465228
+  jsdom.env({
+    html: '',
+    features: { QuerySelector: true },
+    done: function(err, virtual_window) {
+      if (err) {
+        throw err;
+      }
+
+      var virtual_d3 = d3.select(virtual_window.document);
+      virtual_d3.select('body').append('div').attr('id', virtual_element_id);
+
+      var original_d3 = d3;
+      var original_window = global_scope.window;
+      var original_document = global_scope.document;
+      global_scope.d3 = virtual_d3;
+      global_scope.window = virtual_window;
+      global_scope.document = virtual_window.document;
+
+      var target = '#' + virtual_element_id;
+      function get_markup() {
+        return virtual_d3.select(target).html();
+      }
+      fn(target, get_markup);
+
+      global_scope.d3 = original_d3;
+      global_scope.window = original_window;
+      global_scope.document = original_document;
+    }
+  });
+}
+
+MG.use_virtual_element = use_virtual_element;

--- a/src/js/misc/server.js
+++ b/src/js/misc/server.js
@@ -1,12 +1,8 @@
-function use_virtual_element(fn, jsdom_instance) {
-  var jsdom = jsdom_instance || jsdom;
-  if (typeof jsdom === 'undefined') {
-    (console.error || console.log)('jsdom could not be found.');
+function find_virtual_window(MG, jsdom, callback) {
+  if (MG.virtual_window) {
+    callback(MG.virtual_window);
     return;
   }
-
-  var global_scope = typeof window === 'undefined' ? global : window;
-  var virtual_element_id = 'virtual_elem';
 
   // inspired by: https://bl.ocks.org/tomgp/c99a699587b5c5465228
   jsdom.env({
@@ -16,28 +12,47 @@ function use_virtual_element(fn, jsdom_instance) {
       if (err) {
         throw err;
       }
-
-      var virtual_d3 = d3.select(virtual_window.document);
-      virtual_d3.select('body').append('div').attr('id', virtual_element_id);
-
-      var original_d3 = d3;
-      var original_window = global_scope.window;
-      var original_document = global_scope.document;
-      global_scope.d3 = virtual_d3;
-      global_scope.window = virtual_window;
-      global_scope.document = virtual_window.document;
-
-      var target = '#' + virtual_element_id;
-      function get_markup() {
-        return virtual_d3.select(target).html();
-      }
-      fn(target, get_markup);
-
-      global_scope.d3 = original_d3;
-      global_scope.window = original_window;
-      global_scope.document = original_document;
+      MG.virtual_window = virtual_window;
+      callback(virtual_window);
     }
   });
 }
 
+function use_virtual_element(fn, jsdom_instance) {
+  var jsdom = jsdom_instance || jsdom;
+  if (typeof jsdom === 'undefined') {
+    (console.error || console.log)('jsdom could not be found.');
+    return;
+  }
+
+  var global_scope = typeof window === 'undefined' ? global : window;
+
+  find_virtual_window(MG, jsdom, function(virtual_window) {
+    var virtual_d3 = d3.select(virtual_window.document);
+    var virtual_element_id = 'elem-' + MG.virtual_element_id++;
+    virtual_d3.select('body').append('div').attr('id', virtual_element_id);
+
+    var original_d3 = global_scope.d3;
+    var original_window = global_scope.window;
+    var original_document = global_scope.document;
+    global_scope.d3 = virtual_d3;
+    global_scope.window = virtual_window;
+    global_scope.document = virtual_window.document;
+
+    var target = '#' + virtual_element_id;
+    function get_markup() {
+      return virtual_d3.select(target).html();
+    }
+    function done() {
+      virtual_d3.select(target).remove();
+    }
+    fn(target, get_markup, done);
+
+    global_scope.d3 = original_d3;
+    global_scope.window = original_window;
+    global_scope.document = original_document;
+  });
+}
+
+MG.virtual_element_id = 0;
 MG.use_virtual_element = use_virtual_element;

--- a/src/js/misc/server.js
+++ b/src/js/misc/server.js
@@ -19,13 +19,13 @@ function find_virtual_window(MG, jsdom, callback) {
 }
 
 function use_virtual_element(fn, jsdom_instance) {
-  var jsdom = jsdom_instance || jsdom;
+  var global_scope = typeof window === 'undefined' ? global : window;
+
+  var jsdom = jsdom_instance || global_scope.jsdom;
   if (typeof jsdom === 'undefined') {
     (console.error || console.log)('jsdom could not be found.');
     return;
   }
-
-  var global_scope = typeof window === 'undefined' ? global : window;
 
   find_virtual_window(MG, jsdom, function(virtual_window) {
     var virtual_d3 = d3.select(virtual_window.document);

--- a/src/js/misc/server.js
+++ b/src/js/misc/server.js
@@ -46,7 +46,11 @@ function use_virtual_element(fn, jsdom_instance) {
     function done() {
       virtual_d3.select(target).remove();
     }
-    fn(target, get_markup, done);
+    try {
+      fn(target, get_markup, done);
+    } catch(e) {
+      (console.error || console.log)(e);
+    }
 
     global_scope.d3 = original_d3;
     global_scope.window = original_window;


### PR DESCRIPTION
**ETA:** Closing this PR, will open a new one soon. The reason being that all the code worked fine in my test project (which ran in a Node environment), but I overlooked the limitation of jsdom only working on the server side. This means the server rendering will be kind of useless for a universal React app, where the same initial render is expected to take place for both the client and server.

This shouldn't be too hard to patch and fix, but it will require breaking the API I already announced, so I'd rather create a new branch and submit a second PR less cluttered with comments.

---

Solves #650 

## Summary

I was certainly surprised that I got this to work after a night of fiddling around.

```javascript
MG.use_virtual_element(callback[, jsdom]);
```
(If `jsdom` isn't specified, it will be expected in the global scope. 99 times out of 100 you should specify it.)

During the **synchronous** duration of the specified callback function, the global scope's `window` and `document` objects will become virtual instances from `jsdom` and the global instance of `d3` will act upon our virtual DOM (as will anything `MG` functions do that uses `d3`). As soon as the callback ends those global changes are reverted. This is sort of a dirty way of doing it, but conversely it's the cleanest way of working within the library architecture constraints.

The callback gets called with three arguments:
```javascript
callback(target, get_markup, done);
```
* `target` is a string element selector which should be used as the `target` option for SVG rendering.
* `get_markup` is a function which returns the current html content of the target element (presumably an SVG, if you're using this correctly).
* `done` is a function which frees the target node from the virtual DOM. It should be called when the node is no longer needed.

## Example
```javascript
// This will fail if performed in the Node console i.e. global scope,
// because MG will be overwritten! Not applicable for a real app, but
// if you're testing in the console just get rid of 'var MG = '.

var MG = require('metrics-graphics');
var jsdom = require('jsdom');

MG.use_virtual_element(function(target, get_markup, done) {
  MG.data_graphic({
    x_axis: false,
    y_axis: false,
    data: [{
      day: 1,
      traffic: 50
    }, {
      day: 2,
      traffic: 60
    }],
    target: target,
    x_accessor: 'day',
    y_accessor: 'traffic',
    // make sure this is set so we don't try using jquery on the server!
    show_tooltips: false
  });
  console.log(get_markup());
  done();
}, jsdom);
```
Logs:
```
<svg class="" width="350" height="220" viewBox="0 0 350 220"><defs class="mg-clip-path"><clippath id="mg-plot-window-virtual_elem"><rect x="50" y="65" width="282" height="103"></rect></clippath></defs><path class="mg-main-area mg-area1 mg-area1-color" d="M58,90.5C58,90.5,149.33333333333334,72.65,195,75.2C240.66666666666666,77.75,332,105.80000000000001,332,105.80000000000001L332,167C332,167,240.66666666666666,167,195,167C149.33333333333334,167,58,167,58,167Z" fill="" clip-path="url(#mg-plot-window-virtual_elem)"></path><path class="mg-main-line mg-line1 mg-line1-color" d="M58,90.5C58,90.5,149.33333333333334,72.65,195,75.2C240.66666666666666,77.75,332,105.80000000000001,332,105.80000000000001" clip-path="url(#mg-plot-window-virtual_elem)"></path><g class="mg-active-datapoint-container"></g><circle cx="0" cy="0" r="0" class="mg-line1 mg-line1-color mg-area1-color mg-line-rollover-circle"></circle><g class="mg-rollover-rect"><rect class="mg-line1-color mg-line1" x="58.00" y="65" width="68.50" height="102" opacity="0"></rect><rect class="mg-line1-color mg-line1" x="126.50" y="65" width="137.00" height="102" opacity="0"></rect><rect class="mg-line1-color mg-line1" x="263.50" y="65" width="68.50" height="102" opacity="0"></rect></g></svg>
```

### Remember
You will get errors if you try doing anything on the server that would require a real DOM, e.g. measuring the dimensions of something. That means `full_width` isn't allowed for config, for example. It can be passed later on the client side, if you want it. The advantage is that you still have SOMETHING to show as soon as the page loads, even if its dimensions might need to adjust.

### Question
Should I commit my built files as well?
