### PR TITLE
Universal markup rendering

### DIFF
--- a/gulp/index.js
+++ b/gulp/index.js
@@ -48,6 +48,7 @@ var
     src + 'misc/smoothers.js',
     src + 'misc/formatters.js',
     src + 'misc/transitions.js',
+    src + 'misc/markup.js',
     src + 'misc/error.js'
   ];
 

--- a/src/js/MG.js
+++ b/src/js/MG.js
@@ -1,1 +1,1 @@
-window.MG = {version: '2.10.1'};
+(typeof window === 'undefined' ? global : window).MG = {version: '2.10.1'};

--- a/src/js/misc/markup.js
+++ b/src/js/misc/markup.js
@@ -1,0 +1,66 @@
+// influenced by https://bl.ocks.org/tomgp/c99a699587b5c5465228
+
+function render_markup_for_server(callback) {
+  var virtual_window = MG.virtual_window;
+  var virtual_d3 = d3.select(virtual_window.document);
+  var target = virtual_window.document.createElement('div');
+
+  var original_d3 = global.d3;
+  var original_window = global.window;
+  var original_document = global.document;
+  global.d3 = virtual_d3;
+  global.window = virtual_window;
+  global.document = virtual_window.document;
+
+  var error;
+  try {
+    callback(target);
+  } catch(e) {
+    error = e;
+  }
+
+  global.d3 = original_d3;
+  global.window = original_window;
+  global.document = original_document;
+
+  if (error) {
+    throw error;
+  }
+
+  /* for some reason d3.select parses jsdom elements incorrectly
+   * but it works if we wrap the element in a function.
+   */
+  return virtual_d3.select(function targetFn() {
+    return target;
+  }).html();
+}
+
+function render_markup_for_client(callback) {
+  var target = document.createElement('div');
+  callback(target);
+  return d3.select(target).html();
+}
+
+function render_markup(callback) {
+  switch(typeof window) {
+    case 'undefined':
+      return render_markup_for_server(callback);
+    default:
+      return render_markup_for_client(callback);
+  }
+}
+
+function init_virtual_window(jsdom, force) {
+  if (MG.virtual_window && !force) {
+    return;
+  }
+
+  var doc = jsdom.jsdom({
+    html: '',
+    features: { QuerySelector: true }
+  });
+  MG.virtual_window = doc.defaultView;
+}
+
+MG.render_markup = render_markup;
+MG.init_virtual_window = init_virtual_window;

--- a/src/js/misc/utility.js
+++ b/src/js/misc/utility.js
@@ -341,7 +341,7 @@ function mg_target_ref(target) {
   if (typeof target === 'string') {
     return mg_normalize(target);
 
-  } else if (target instanceof HTMLElement) {
+  } else if (target instanceof window.HTMLElement) {
     target_ref = target.getAttribute('data-mg-uid');
     if (!target_ref) {
       target_ref = mg_next_id();


### PR DESCRIPTION
Solves #650 

*My original PR that attempted to address this was #722, which works for the server but not the client. In order to simplify the API I ditched the async variant, which was pointless on the client and provided no benefit on the server after the first render.*

Use `MG.render_markup` to produce SVG string markup for a chart. Works both on the client, using the DOM, and on the server, using `jsdom` (which must be supplied by the user). Useful if, for instance, you have a universal React app which needs to render the same initial markup on the server and client.

```javascript
MG.render_markup(callback);
```

The callback gets called with `target`, the DOM node inside of which the SVG will be rendered. Use this element as the `target` option for chart rendering.
```javascript
callback(target);
```

On the server, `jsdom` must be passed into `MG.init_virtual_window` before `MG.render_markup` can be called:
```javascript
MG.init_virtual_window(jsdom[, force]);
```
After the initial call to `init_virtual_window` subsequent calls will be ignored, though passing a truthy second argument (`force`) will override this behavior and re-initialize the virtual window.

## Working Example (Client and Server)
```javascript
// This will fail if performed in the Node console i.e. global scope,
// because MG will be overwritten! Not applicable for a real app, but
// if you're testing in the console just get rid of 'var MG = '.

var MG = require('metrics-graphics');

// are we on the server?
if (typeof window === 'undefined') {
  MG.init_virtual_window(require('jsdom'));
}

var markup = MG.render_markup(function(target) {
  MG.data_graphic({
    target: target,
    x_axis: false,
    y_axis: false,
    data: [{
      day: 1,
      traffic: 50
    }, {
      day: 2,
      traffic: 60
    }],
    x_accessor: 'day',
    y_accessor: 'traffic',
    // make sure this is set so we don't try using jquery on the server!
    show_tooltips: false
  });
});
console.log(markup);
```
Logs:
```
<svg class="" width="350" height="220" viewBox="0 0 350 220"><defs class="mg-clip-path"><clippath id="mg-plot-window-mg-0"><rect x="50" y="65" width="282" height="103"></rect></clippath></defs><path class="mg-main-area mg-area1 mg-area1-color" d="M58,90.5L332,75.2L332,167L58,167Z" fill="" clip-path="url(#mg-plot-window-mg-0)"></path><path class="mg-main-line mg-line1 mg-line1-color" d="M58,90.5L332,75.2" clip-path="url(#mg-plot-window-mg-0)"></path><g class="mg-active-datapoint-container"></g><circle cx="0" cy="0" r="0" class="mg-line1 mg-line1-color mg-area1-color mg-line-rollover-circle"></circle><g class="mg-rollover-rect"><rect class="mg-line1-color mg-line1" x="58.00" y="65" width="137.00" height="102" opacity="0"></rect><rect class="mg-line1-color mg-line1" x="195.00" y="65" width="137.00" height="102" opacity="0"></rect></g></svg>
```

**Server-only behavior**
During the **synchronous** duration of the specified callback function, the global scope's `window` and `document` objects will become virtual instances from `jsdom` and the global instance of `d3` will act upon our virtual DOM. As soon as the callback ends those global changes are reverted. This is sort of a dirty way of doing it, but conversely it's the cleanest way of working within the library architecture constraints.

**Client bundling issues**
Bundlers for the client like webpack will throw a fit if you try to require `jsdom`, which has C dependencies. You can [tell webpack to ignore jsdom](https://github.com/webpack/webpack/issues/718#issuecomment-84936730), though.

### Remember
You will get errors if you try doing anything on the server that would require a real DOM, e.g. measuring the dimensions of something. That means `full_width` isn't allowed for config, for example. It can be passed later on the client side, if you want it. The advantage is that you still have SOMETHING to show as soon as the page loads, even if its dimensions might need to adjust.

### Question
Should I commit my built files as well?
