### PR TITLE
Fix #653 : removed unused es6-module-transpiler

### DIFF
--- a/gulp/index.js
+++ b/gulp/index.js
@@ -10,8 +10,7 @@ var
   //minifycss = require('gulp-minify-css'), // for minifiing css
   jshint = require('gulp-jshint'),
   testem = require('gulp-testem'),
-  connect = require('gulp-connect'),
-  es6ModuleTranspiler = require("gulp-es6-module-transpiler");
+  connect = require('gulp-connect');
 
 // paths
 var

--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
     "gulp": "^3.8.10",
     "gulp-concat": "^2.4.2",
     "gulp-connect": "^2.2.0",
-    "gulp-es6-module-transpiler": "^0.2.0",
     "gulp-jshint": "^1.9.0",
     "gulp-rename": "^1.2.0",
     "gulp-rimraf": "^0.1.1",


### PR DESCRIPTION
This tiny PR should make building the library from scratch easier. I believe the only manual step beyond `npm install ; guild build:js` is to first `npm install -g gulp-cli`.

As far as I can tell gulp-es6-module-transpiler is no longer used for anything but breaks the build unless you manually `npm install recast`. There is only a single `require` for the module and the resulting variable is unused.

Just for safety I compared the resulting built version of the library in `./dist` with and without this change and they are identical (other than the fact that `./dist` is currently out of sync, see #725)
