### PR TITLE
Fix #724: declare variable `target_ref` before usage.

### DIFF
--- a/src/js/misc/utility.js
+++ b/src/js/misc/utility.js
@@ -342,7 +342,7 @@ function mg_target_ref(target) {
     return mg_normalize(target);
 
   } else if (target instanceof window.HTMLElement) {
-    target_ref = target.getAttribute('data-mg-uid');
+    var target_ref = target.getAttribute('data-mg-uid');
     if (!target_ref) {
       target_ref = mg_next_id();
       target.setAttribute('data-mg-uid', target_ref);


### PR DESCRIPTION
Declare variable `target_ref` before using it. The fix resolves https://github.com/mozilla/metrics-graphics/issues/724, where running metrics-graphics in a node.js cluster thread would throw "reference error" when `target_ref` [is used](https://github.com/mozilla/metrics-graphics/blob/443e47a0cfb0ca82b82a36441a385c73efc0dc57/src/js/misc/utility.js#L345) before being declared (probably runs in strict mode).