### PR TITLE
Add mouse out events on marker text

### DIFF
--- a/examples/charts/annotations.htm
+++ b/examples/charts/annotations.htm
@@ -133,6 +133,44 @@
             </div>
 
             <div class='row trunk-section'>
+                <div class='col-lg-7 text-center' id='markers-mouseout'></div>
+                <div class='col-lg-5'>
+                    <div class='data-column'><a href='data/some_percentage.json'>data</a></div>
+
+                    <pre><code class='javascript'>d3.json('data/some_percentage.json', function(data) {
+    for (var i = 0; i < data.length; i++) {
+        data[i] = MG.convert.date(data[i], 'date');
+    }
+
+      var mouseout = function() {
+        alert("You just left me!");
+    };
+
+    var markers = [{
+        'date': new Date('2014-02-01T00:00:00.000Z'),
+        'label': "Place your mouse here and out!",
+        'mouseout': mouseout
+    }, {
+        'date': new Date('2014-03-15T00:00:00.000Z'),
+        'label': "Nothing to see here"
+    }];
+
+    MG.data_graphic({
+        title: "Mouse Out Markers",
+        description: "You can assign arbitrary functions to markers' mouseout events.",
+        data: data,
+        width: 600,
+        height: 200,
+        right: 40,
+        markers: markers,
+        format: 'percentage',
+        target: '#markers-mouseout'
+    });</code></pre>
+
+                </div>
+            </div>
+
+            <div class='row trunk-section'>
                 <div class='col-lg-7 text-center mg-main-area-solid' id='spike'></div>
                 <div class='col-lg-5'>
                     <div class='data-column'><a href='data/fake_users1.json'>data</a></div>
@@ -236,6 +274,32 @@ d3.json('data/some_percentage.json', function(data) {
         format: 'percentage',
         target: '#markers-mouseover'
     });
+
+    var mouseout = function() {
+        alert("You just left me!");
+    };
+
+    markers = [{
+        'date': new Date('2014-02-01T00:00:00.000Z'),
+        'label': "Place your mouse here and out!",
+        'mouseout': mouseout
+    }, {
+        'date': new Date('2014-03-15T00:00:00.000Z'),
+        'label': "Nothing to see here"
+    }];
+
+    MG.data_graphic({
+        title: "Mouse Out Markers",
+        description: "You can assign arbitrary functions to markers' mouseout events.",
+        data: data,
+        width: 600,
+        height: 200,
+        right: 40,
+        markers: markers,
+        format: 'percentage',
+        target: '#markers-mouseout'
+    });
+
 });
 
 d3.json('data/fake_users1.json', function(data) {

--- a/examples/charts/annotations.htm
+++ b/examples/charts/annotations.htm
@@ -111,28 +111,6 @@
             </div>
 
             <div class='row trunk-section'>
-                <div class='col-lg-7 text-center' id='baselines'></div>
-                <div class='col-lg-5'>
-                    <div class='data-column'><a href='data/fake_users1.json'>data</a></div>
-
-<pre><code class='javascript'>d3.json('data/fake_users1.json', function(data) {
-    data = MG.convert.date(data, 'date');
-    MG.data_graphic({
-        title: "Baselines",
-        description: "Baselines are horizontal lines that can added at arbitrary points.",
-        data: data,
-        baselines: [{value: 160000000, label: 'a baseline'}],
-        width: 600,
-        height: 200,
-        right: 40,
-        target: '#baselines'
-    });
-});</code></pre>
-
-                </div>
-            </div>
-
-            <div class='row trunk-section'>
                 <div class='col-lg-7 text-center' id='markers-mouseout'></div>
                 <div class='col-lg-5'>
                     <div class='data-column'><a href='data/some_percentage.json'>data</a></div>
@@ -142,7 +120,7 @@
         data[i] = MG.convert.date(data[i], 'date');
     }
 
-      var mouseout = function() {
+    var mouseout = function() {
         alert("You just left me!");
     };
 
@@ -166,6 +144,28 @@
         format: 'percentage',
         target: '#markers-mouseout'
     });</code></pre>
+
+                </div>
+            </div>
+
+            <div class='row trunk-section'>
+                <div class='col-lg-7 text-center' id='baselines'></div>
+                <div class='col-lg-5'>
+                    <div class='data-column'><a href='data/fake_users1.json'>data</a></div>
+
+<pre><code class='javascript'>d3.json('data/fake_users1.json', function(data) {
+    data = MG.convert.date(data, 'date');
+    MG.data_graphic({
+        title: "Baselines",
+        description: "Baselines are horizontal lines that can added at arbitrary points.",
+        data: data,
+        baselines: [{value: 160000000, label: 'a baseline'}],
+        width: 600,
+        height: 200,
+        right: 40,
+        target: '#baselines'
+    });
+});</code></pre>
 
                 </div>
             </div>

--- a/src/js/common/markers.js
+++ b/src/js/common/markers.js
@@ -87,6 +87,10 @@ function mg_place_marker_text(gm, args) {
           d3.select(this).style('cursor', 'pointer')
             .on('mouseover', d.mouseover);
         }
+        if (d.mouseout) {
+            d3.select(this).style('cursor', 'pointer')
+                .on('mouseout', d.mouseout);
+        }
       });
 
   mg_prevent_horizontal_overlap(gm.selectAll('.mg-marker-text').nodes(), args);


### PR DESCRIPTION
- Adds "mouse out events on marker text". 
- Documentation included.
- Based on previously merged pull request https://github.com/mozilla/metrics-graphics/pull/777 (Add mouse over events on Marker text)