### PR TITLE
Update d3.js link in examples/index.htm

### DIFF
--- a/examples/index.htm
+++ b/examples/index.htm
@@ -25,7 +25,7 @@
 
     <script src='js/lib/highlight.pack.js'></script>
     <script src='https://ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js'></script>
-    <script src='https://cdnjs.cloudflare.com/ajax/libs/d3/3.5.0/d3.min.js' charset='utf-8'></script>
+    <script src='https://d3js.org/d3.v4.min.js' charset='utf-8'></script>
     <script src='../dist/metricsgraphics.min.js'></script>
 
     <script>


### PR DESCRIPTION
update link from d3 3.5.0 to v4. Current version of MG requires d3v4 since it uses objects like `d3.curveCatmullRom` nonexistent in d3 3.5.0.
Although index.htm page does not demo any charting on that page itself, it might mislead newcomers such as myself because index.htm is the simplest page to start with and it uses 3.5.0, one might experience same problems as I did(false dependency).