### PR TITLE
Fix aggregated rollover circle displayed on missing data

### DIFF
--- a/src/js/charts/line.js
+++ b/src/js/charts/line.js
@@ -642,8 +642,7 @@
         .style('opacity', 0);
 
       d.values.forEach(function(datum, index, list) {
-
-        if(args.missing_is_hidden && list[index]['_missing']) {
+        if (args.missing_is_hidden && list[index]['_missing']) {
           return;
         }
 

--- a/src/js/charts/line.js
+++ b/src/js/charts/line.js
@@ -641,7 +641,12 @@
       svg.selectAll('circle.mg-line-rollover-circle')
         .style('opacity', 0);
 
-      d.values.forEach(function(datum) {
+      d.values.forEach(function(datum, index, list) {
+
+        if(args.missing_is_hidden && list[index]['_missing']) {
+          return;
+        }
+
         if (mg_data_in_plot_bounds(datum, args)) mg_update_aggregate_rollover_circle(args, svg, datum);
       });
     } else if ((args.missing_is_hidden && d['_missing']) || d[args.y_accessor] === null) {


### PR DESCRIPTION
This PR fixes aggregated rollover circle displayed on lines having their data missing/hidden.

**Before:**
![before](https://user-images.githubusercontent.com/151973/34469749-ec2c15b0-ef25-11e7-8598-e8affc8e9857.JPG)

**After:**
![after](https://user-images.githubusercontent.com/151973/34469779-f0451cc8-ef25-11e7-8879-5d300c7fff0e.JPG)

