### PR TITLE
Fix overlapping of label and ticks in the y-axis

### DIFF
--- a/src/js/common/y_axis.js
+++ b/src/js/common/y_axis.js
@@ -896,7 +896,7 @@ function mg_add_y_label (g, args) {
       .attr('y', function () {
         return args.left / 2;
       })
-      .attr('dy', '0.4em')
+      .attr('dy', '-1.2em')
       .attr('text-anchor', 'middle')
       .text(function (d) {
         return args.y_label;


### PR DESCRIPTION
fixes: #764 
Screenshot of the changes is as follows:
![image](https://user-images.githubusercontent.com/30361728/35840739-20704aee-0b1e-11e8-9ede-3bfdbbc44f5e.png)
@wlach, Please review