### PR TITLE
Fix of mozilla/metrics-graphics#825: Gulp "build:js" task generate a wrong dist/metricsgraphics.js UMD formated file

### DIFF
--- a/gulp/index.js
+++ b/gulp/index.js
@@ -72,6 +72,9 @@ gulp.task('clean', function () {
 gulp.task('build:js', ['clean'], function () {
   return gulp.src(jsFiles)
     .pipe(concat({path: 'metricsgraphics.js'}))
+    .pipe(babel({
+      presets: ['env']
+    }))
     .pipe(umd(
         {
           dependencies:function() {
@@ -91,9 +94,6 @@ gulp.task('build:js', ['clean'], function () {
           }
         }
     ))
-    .pipe(babel({
-      presets: ['env']
-    }))
     .pipe(gulp.dest(dist))
     .pipe(rename('metricsgraphics.min.js'))
     .pipe(uglify())


### PR DESCRIPTION
This PR fix production bug #825 

**Solution:** Babel transpilation process has been moved up to UMD packaging.

Requires of course to re-run gulp **build:js** to fix that line in production: https://github.com/mozilla/metrics-graphics/blob/master/dist/metricsgraphics.js#L13

Hope this helps!

Thomas

