### PR TITLE
Change the algorithm for calculate decimals of format y-axis ticks (Fixes #821)

### DIFF
--- a/src/js/common/y_axis.js
+++ b/src/js/common/y_axis.js
@@ -800,16 +800,17 @@ function mg_compute_yax_format (args) {
   if (!yax_format) {
     if (args.format === 'count') {
       // increase decimals if we have small values, useful for realtime data
-      if (args.processed.max_y < 0.0001) {
-        args.decimals = 6;
-      } else if (args.processed.max_y < 0.1) {
-        args.decimals = 4;
+      if (args.processed.y_ticks.length > 1) {
+        // calculate the number of decimals between the difference of ticks
+        args.decimals = Math.max(0, -Math.floor(
+          Math.log(args.processed.y_ticks[1] - args.processed.y_ticks[0]) / Math.LN10
+        ))
       }
 
       yax_format = function (d) {
         var pf;
 
-        if (d < 1.0 && d > -1.0 && d !== 0) {
+        if (args.decimals !== 0) {
           // don't scale tiny values
           pf = d3.format(',.' + args.decimals + 'f');
         } else if (d < 1000) {

--- a/src/js/common/y_axis.js
+++ b/src/js/common/y_axis.js
@@ -802,6 +802,7 @@ function mg_compute_yax_format (args) {
       // increase decimals if we have small values, useful for realtime data
       if (args.processed.y_ticks.length > 1) {
         // calculate the number of decimals between the difference of ticks
+        // based on approach in flot: https://github.com/flot/flot/blob/958e5fd43c6dff4bab3e1fd5cb6109df5c1e8003/jquery.flot.js#L1810
         args.decimals = Math.max(0, -Math.floor(
           Math.log(args.processed.y_ticks[1] - args.processed.y_ticks[0]) / Math.LN10
         ))


### PR DESCRIPTION
Solve #821 by calculating the number of decimals between the difference of ticks.

Reference https://github.com/flot/flot/blob/master/jquery.flot.js#L1810

`Math.max(0, -Math.floor(Math.log(number) / Math.LN10)) ` this can be used to calculate the number of decimal places for the first significant digit of `number`, so we can ensure that the number of reserved decimals is enough.