### PR TITLE
Use closures instead of `this` inside hover text code (fixes #828)

### DIFF
--- a/src/js/charts/histogram.js
+++ b/src/js/charts/histogram.js
@@ -154,7 +154,7 @@
         if (args.show_rollover_text) {
           const mo = mg_mouseover_text(args, { svg });
           const row = mo.mouseover_row();
-          row.text('\u259F  ').elem()
+          row.text('\u259F  ').elem
             .classed('hist-symbol', true);
 
           row.text(mg_format_x_mouseover(args, d)); // x

--- a/src/js/charts/line.js
+++ b/src/js/charts/line.js
@@ -836,10 +836,10 @@
             }
 
             if (args.legend) {
-              mg_line_color_text(row.text(`${args.legend[di.index - 1]}  `).bold().elem(), di, args);
+              mg_line_color_text(row.text(`${args.legend[di.index - 1]}  `).bold().elem, di, args);
             }
 
-            mg_line_color_text(row.text('\u2014  ').elem(), di, args);
+            mg_line_color_text(row.text('\u2014  ').elem, di, args);
             if (!args.aggregate_rollover) {
               row.text(mg_format_x_mouseover(args, di));
             }

--- a/src/js/charts/point.js
+++ b/src/js/charts/point.js
@@ -4,10 +4,10 @@ function point_mouseover(args, svg, d) {
 
   if (args.color_accessor !== null && args.color_type === 'category') {
     const label = d[args.color_accessor];
-    row.text(`${label}  `).bold().elem().attr('fill', args.scalefns.colorf(d));
+    row.text(`${label}  `).bold().attr('fill', args.scalefns.colorf(d));
   }
 
-  mg_color_point_mouseover(args, row.text('\u25CF   ').elem(), d); // point shape
+  mg_color_point_mouseover(args, row.text('\u25CF   ').elem, d); // point shape
 
   row.text(mg_format_x_mouseover(args, d)); // x
   row.text(mg_format_y_mouseover(args, d, args.time_series === false));

--- a/src/js/common/rollover.js
+++ b/src/js/common/rollover.js
@@ -47,35 +47,15 @@ function mg_setup_mouseover_container(svg, args) {
 }
 
 function mg_mouseover_tspan(svg, text) {
-  var tspan = '';
-  var cl = null;
-  if (arguments.length === 3) cl = arguments[2];
-  tspan = svg.append('tspan').text(text);
-  if (cl !== null) tspan.classed(cl, true);
-  this.tspan = tspan;
+  let tspan = svg.append('tspan').text(text);
 
-  this.bold = function() {
-    this.tspan.attr('font-weight', 'bold');
-    return this;
+  return {
+    bold: () => tspan.attr('font-weight', 'bold'),
+    font_size: (pts) => tspan.attr('font-size', pts),
+    x: (x) => tspan.attr('x', x),
+    y: (y) => tspan.attr('y', y),
+    elem: tspan
   };
-
-  this.font_size = function(pts) {
-    this.tspan.attr('font-size', pts);
-    return this;
-  }
-
-  this.x = function(x) {
-    this.tspan.attr('x', x);
-    return this;
-  };
-  this.y = function(y) {
-    this.tspan.attr('y', y);
-    return this;
-  };
-  this.elem = function() {
-    return this.tspan;
-  };
-  return this;
 }
 
 function mg_reset_text_container(svg) {
@@ -88,32 +68,30 @@ function mg_reset_text_container(svg) {
 
 function mg_mouseover_row(row_number, container, rargs) {
   var lineHeight = 1.1;
-  this.rargs = rargs;
-
   var rrr = container.append('tspan')
     .attr('x', 0)
     .attr('y', (row_number * lineHeight) + 'em');
 
-  this.text = function(text) {
-    return mg_mouseover_tspan(rrr, text);
-  }
-  return this;
+  return {
+    rargs,
+    text: (text) => {
+      return mg_mouseover_tspan(rrr, text);
+    }
+  };
 }
 
 function mg_mouseover_text(args, rargs) {
-  var lineHeight = 1.1;
-  this.row_number = 0;
-  this.rargs = rargs;
   mg_setup_mouseover_container(rargs.svg, args);
 
-  this.text_container = mg_reset_text_container(rargs.svg);
+  let mouseOver = {
+    row_number: 0,
+    rargs,
+    mouseover_row: (rargs) => {
+      mouseOver.row_number += 1;
+      return mg_mouseover_row(mouseOver.row_number, mouseOver.text_container, rargs);
+    },
+    text_container: mg_reset_text_container(rargs.svg)
+  };
 
-  this.mouseover_row = function(rargs) {
-    var that = this;
-    var rrr = mg_mouseover_row(that.row_number, that.text_container, rargs);
-    that.row_number += 1;
-    return rrr;
-  }
-
-  return this;
+  return mouseOver;
 }


### PR DESCRIPTION
`this` in these functions used to resolve to window (which wasn't great
to begin with), but that broke entirely when we started using babel.